### PR TITLE
Remove: mesex.java lookup

### DIFF
--- a/menuentryswapperextended/menuentryswapperextended.gradle.kts
+++ b/menuentryswapperextended/menuentryswapperextended.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.5"
+version = "0.0.6"
 
 project.extra["PluginName"] = "Menu Entry Swapper Extended"
 project.extra["PluginDescription"] = "Change the default option that is displayed when hovering over objects"

--- a/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/MenuEntrySwapperExtendedConfig.java
+++ b/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/MenuEntrySwapperExtendedConfig.java
@@ -490,18 +490,6 @@ public interface MenuEntrySwapperExtendedConfig extends Config
 		return false;
 	}
 
-	@ConfigItem(
-		keyName = "hideLookup",
-		name = "Lookup",
-		description = "Hides the 'Lookup' option from the right click menu.",
-		position = 3,
-		section = "rightClickOptionsSection"
-	)
-	default boolean hideLookup()
-	{
-		return false;
-	}
-
 	//------------------------------------------------------------//
 	// PVM
 	//------------------------------------------------------------//

--- a/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/MenuEntrySwapperExtendedPlugin.java
+++ b/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/MenuEntrySwapperExtendedPlugin.java
@@ -346,11 +346,6 @@ public class MenuEntrySwapperExtendedPlugin extends Plugin
 				continue;
 			}
 
-			if (option.contains("lookup") && config.hideLookup())
-			{
-				continue;
-			}
-
 			if (option.contains("report") && config.hideReport())
 			{
 				continue;


### PR DESCRIPTION
Removes the menu entry swappers hide lookup option as its already located inside hiscores, https://i.imgur.com/40T9H2k.jpg