### PR TITLE
betteropponentinfo: adds opponents opponent back in multi combat

### DIFF
--- a/betteropponentinfo/betteropponentinfo.gradle.kts
+++ b/betteropponentinfo/betteropponentinfo.gradle.kts
@@ -1,0 +1,60 @@
+import ProjectVersions.rlVersion
+
+/*
+ * Copyright (c) 2019 Owain van Brakel <https://github.com/Owain94>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+version = "0.0.1"
+
+project.extra["PluginName"] = "Better Opponent Information"
+project.extra["PluginDescription"] = "Show name and hitpoints information about the NPC you are fighting"
+
+dependencies {
+    annotationProcessor(Libraries.lombok)
+    annotationProcessor(Libraries.pf4j)
+
+    compileOnly("com.openosrs:runelite-api:$rlVersion")
+    compileOnly("com.openosrs:runelite-client:$rlVersion")
+    compileOnly("com.openosrs:http-api:$rlVersion")
+
+    compileOnly(Libraries.guice)
+    compileOnly(Libraries.javax)
+    compileOnly(Libraries.lombok)
+    compileOnly(Libraries.pf4j)
+    compileOnly(Libraries.rxjava)
+}
+
+tasks {
+    jar {
+        manifest {
+            attributes(mapOf(
+                    "Plugin-Version" to project.version,
+                    "Plugin-Id" to nameToId(project.extra["PluginName"] as String),
+                    "Plugin-Provider" to project.extra["PluginProvider"],
+                    "Plugin-Description" to project.extra["PluginDescription"],
+                    "Plugin-License" to project.extra["PluginLicense"]
+            ))
+        }
+    }
+}

--- a/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/BetterOpponentInfoConfig.java
+++ b/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/BetterOpponentInfoConfig.java
@@ -44,10 +44,10 @@ public interface BetterOpponentInfoConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showOpponentsOpponent",
-			name = "Show opponent's opponent",
-			description = "Toggle showing opponent's opponent if within a multi-combat area",
-			position = 1
+		keyName = "showOpponentsOpponent",
+		name = "Show opponent's opponent",
+		description = "Toggle showing opponent's opponent if within a multi-combat area",
+		position = 1
 	)
 	default boolean showOpponentsOpponent()
 	{

--- a/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/BetterOpponentInfoConfig.java
+++ b/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/BetterOpponentInfoConfig.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.betteropponentinfo;
+
+import java.awt.Color;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("betteropponentinfo")
+public interface BetterOpponentInfoConfig extends Config
+{
+	@ConfigItem(
+		keyName = "lookupOnInteraction",
+		name = "Lookup players on interaction",
+		description = "Display a combat stat comparison panel on player interaction. (follow, trade, challenge, attack, etc.)",
+		position = 0
+	)
+	default boolean lookupOnInteraction()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "showOpponentsOpponent",
+			name = "Show opponent's opponent",
+			description = "Toggle showing opponent's opponent if within a multi-combat area",
+			position = 1
+	)
+	default boolean showOpponentsOpponent()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "hitpointsDisplayStyle",
+		name = "Hitpoints display style",
+		description = "Show opponent's hitpoints as a value (if known), percentage, or both",
+		position = 2
+	)
+	default HitpointsDisplayStyle hitpointsDisplayStyle()
+	{
+		return HitpointsDisplayStyle.HITPOINTS;
+	}
+
+	@ConfigItem(
+		keyName = "showAttackersMenu",
+		name = "Show attackers in menu",
+		description = "Marks attackers' names in menus with a *<br>",
+		position = 3,
+		warning = "NOTE: This'll also mark people who are following you/interacting with you in any other way. Don't blindly trust this in pvp!"
+	)
+	default boolean showAttackersMenu()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showAttackingMenu",
+		name = "Green main target",
+		description = "Display main target's name colored in menus (Players and NPCs)",
+		position = 4,
+		warning = "NOTE: This'll also show green when following/interacting in any other way. Don't blindly trust this in pvp!"
+	)
+	default boolean showAttackingMenu()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "attackingColor",
+		name = "Target color",
+		description = "The color your target will be highlighted with",
+		position = 5
+	)
+	default Color attackingColor()
+	{
+		return Color.GREEN;
+	}
+
+	@ConfigItem(
+		keyName = "showHitpointsMenu",
+		name = "Show NPC hp in menu",
+		description = "Show NPC hp in menu. Useful when barraging",
+		position = 6
+	)
+	default boolean showHitpointsMenu()
+	{
+		return false;
+	}
+}

--- a/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/BetterOpponentInfoPlugin.java
+++ b/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/BetterOpponentInfoPlugin.java
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2016-2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.betteropponentinfo;
+
+import com.google.inject.Provides;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.EnumSet;
+import javax.inject.Inject;
+import lombok.AccessLevel;
+import lombok.Getter;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.MenuOpcode;
+import net.runelite.api.NPC;
+import net.runelite.api.Player;
+import net.runelite.api.WorldType;
+import net.runelite.api.events.BeforeRender;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.MenuOpened;
+import net.runelite.api.util.Text;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.game.HiscoreManager;
+import net.runelite.client.game.NPCManager;
+import net.runelite.client.menus.MenuManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.PluginType;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.http.api.hiscore.HiscoreEndpoint;
+import net.runelite.http.api.hiscore.HiscoreResult;
+import org.pf4j.Extension;
+
+@Extension
+@PluginDescriptor(
+	name = "Better Opponent Information",
+	description = "Show name and hitpoints information about the NPC you are fighting",
+	tags = {"combat", "health", "hitpoints", "npcs", "overlay"},
+	type = PluginType.UTILITY
+)
+public class BetterOpponentInfoPlugin extends Plugin
+{
+	private static final Duration WAIT = Duration.ofSeconds(5);
+	private static final Object MENU = new Object();
+	private static final int COLOR_TAG_LENGTH = 12;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private BetterOpponentInfoConfig config;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private OpponentInfoOverlay opponentInfoOverlay;
+
+	@Inject
+	private PlayerComparisonOverlay playerComparisonOverlay;
+
+	@Inject
+	private EventBus eventBus;
+
+	@Inject
+	private HiscoreManager hiscoreManager;
+
+	@Inject
+	private MenuManager menuManager;
+
+	@Inject
+	private NPCManager npcManager;
+
+	@Getter(AccessLevel.PACKAGE)
+	private HiscoreEndpoint hiscoreEndpoint = HiscoreEndpoint.NORMAL;
+
+	@Getter(AccessLevel.PACKAGE)
+	private Actor lastOpponent;
+
+	private Instant lastTime;
+
+	private String attackingColTag;
+	private boolean showAttackers;
+	private boolean showAttacking;
+	private boolean showHitpoints;
+
+	@Provides
+	BetterOpponentInfoConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(BetterOpponentInfoConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		this.attackingColTag = ColorUtil.colorTag(config.attackingColor());
+		this.showAttackers = config.showAttackersMenu();
+		this.showAttacking = config.showAttackingMenu();
+		this.showHitpoints = config.showHitpointsMenu();
+
+		updateMenuSubs();
+
+		overlayManager.add(opponentInfoOverlay);
+		overlayManager.add(playerComparisonOverlay);
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		eventBus.unregister(MENU);
+
+		lastOpponent = null;
+		lastTime = null;
+		overlayManager.remove(opponentInfoOverlay);
+		overlayManager.remove(playerComparisonOverlay);
+	}
+
+	private void updateMenuSubs()
+	{
+		if (showAttackers || showAttacking || showHitpoints)
+		{
+			eventBus.subscribe(BeforeRender.class, MENU, this::onBeforeRender);
+			eventBus.subscribe(MenuOpened.class, MENU, this::onMenuOpened);
+		}
+		else
+		{
+			eventBus.unregister(MENU);
+		}
+	}
+
+	@Subscribe
+	private void onGameStateChanged(GameStateChanged gameStateChanged)
+	{
+		if (gameStateChanged.getGameState() != GameState.LOGGED_IN)
+		{
+			return;
+		}
+
+		final EnumSet<WorldType> worldType = client.getWorldType();
+		if (worldType.contains(WorldType.DEADMAN))
+		{
+			hiscoreEndpoint = HiscoreEndpoint.DEADMAN;
+		}
+		else if (worldType.contains(WorldType.LEAGUE))
+		{
+			hiscoreEndpoint = HiscoreEndpoint.LEAGUE;
+		}
+		else
+		{
+			hiscoreEndpoint = HiscoreEndpoint.NORMAL;
+		}
+	}
+
+	@Subscribe
+	private void onInteractingChanged(InteractingChanged event)
+	{
+		if (event.getSource() != client.getLocalPlayer())
+		{
+			return;
+		}
+
+		Actor opponent = event.getTarget();
+
+		if (opponent == null)
+		{
+			lastTime = Instant.now();
+			return;
+		}
+
+		lastOpponent = opponent;
+	}
+
+	@Subscribe
+	private void onGameTick(GameTick gameTick)
+	{
+		if (lastOpponent != null
+			&& lastTime != null
+			&& client.getLocalPlayer().getInteracting() == null
+			&& Duration.between(lastTime, Instant.now()).compareTo(WAIT) > 0)
+		{
+			lastOpponent = null;
+		}
+
+	}
+
+	@Subscribe
+	private void onConfigChanged(ConfigChanged event)
+	{
+		if (!event.getGroup().equals("betteropponentinfo"))
+		{
+			return;
+		}
+
+		switch (event.getKey())
+		{
+			case "showAttackersMenu":
+				this.showAttackers = config.showAttackersMenu();
+				updateMenuSubs();
+				break;
+			case "showAttackingMenu":
+				this.showAttacking = config.showAttackingMenu();
+				updateMenuSubs();
+				break;
+			case "showHitpointsMenu":
+				this.showHitpoints = config.showHitpointsMenu();
+				updateMenuSubs();
+				break;
+			case "attackingColor":
+				attackingColTag = ColorUtil.colorTag(config.attackingColor());
+				break;
+		}
+	}
+
+	private void onBeforeRender(BeforeRender event)
+	{
+		if (client.getMenuOptionCount() <= 0)
+		{
+			return;
+		}
+		if (client.isMenuOpen())
+		{
+			boolean changed = false;
+			final MenuEntry[] entries = client.getMenuEntries();
+			for (final MenuEntry entry : entries)
+			{
+				changed |= fixup(entry);
+			}
+
+			if (changed)
+			{
+				client.setMenuEntries(entries);
+			}
+			return;
+		}
+
+		final MenuEntry entry = client.getLeftClickMenuEntry();
+		if (modify(entry))
+		{
+			client.setLeftClickMenuEntry(entry);
+		}
+	}
+
+	private void onMenuOpened(MenuOpened event)
+	{
+		boolean changed = false;
+		for (MenuEntry entry : event.getMenuEntries())
+		{
+			changed |= modify(entry);
+		}
+
+		if (changed)
+		{
+			event.setModified();
+		}
+	}
+
+	private boolean modify(MenuEntry entry)
+	{
+		if (isNotAttackEntry(entry))
+		{
+			return false;
+		}
+
+		boolean changed = false;
+
+		int index = entry.getIdentifier();
+		Actor actor = getActorFromIndex(index);
+
+		if (actor == null)
+		{
+			return false;
+		}
+
+		if (actor instanceof Player)
+		{
+			index -= 32768;
+		}
+
+		String target = entry.getTarget();
+
+		if (showAttacking &&
+			client.getLocalPlayer().getRSInteracting() == index)
+		{
+			target = attackingColTag + target.substring(COLOR_TAG_LENGTH);
+			changed = true;
+		}
+
+		if (showAttackers &&
+			actor.getRSInteracting() - 32768 == client.getLocalPlayerIndex())
+		{
+			target = '*' + target;
+			changed = true;
+		}
+
+		if (showHitpoints &&
+			actor.getHealth() > 0)
+		{
+			int lvlIndex = target.lastIndexOf("(level-");
+			if (lvlIndex != -1)
+			{
+				String levelReplacement = getHpString(actor, true);
+
+				target = target.substring(0, lvlIndex) + levelReplacement;
+				changed = true;
+			}
+		}
+
+		if (changed)
+		{
+			entry.setTarget(target);
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean fixup(MenuEntry entry)
+	{
+		if (isNotAttackEntry(entry))
+		{
+			return false;
+		}
+
+		int index = entry.getIdentifier();
+
+		Actor actor = getActorFromIndex(index);
+
+		if (actor == null)
+		{
+			return false;
+		}
+
+		if (actor instanceof Player)
+		{
+			index -= 32768;
+		}
+
+		String target = entry.getTarget();
+
+		boolean hasAggro = actor.getRSInteracting() - 32768 == client.getLocalPlayerIndex();
+		boolean hadAggro = target.charAt(0) == '*';
+		boolean isTarget = client.getLocalPlayer().getRSInteracting() == index;
+		boolean hasHp = showHitpoints && actor instanceof NPC && actor.getHealth() > 0;
+
+		boolean aggroChanged = showAttackers && hasAggro != hadAggro;
+		boolean targetChanged = showAttacking && isTarget != target.startsWith(attackingColTag, aggroChanged ? 1 : 0);
+		boolean hpChanged = showHitpoints && hasHp == target.contains("(level-");
+
+		if (!aggroChanged &&
+			!targetChanged &&
+			!hasHp &&
+			!hpChanged)
+		{
+			return false;
+		}
+
+		if (targetChanged)
+		{
+			boolean player = actor instanceof Player;
+			final int start = hadAggro ? 1 + COLOR_TAG_LENGTH : COLOR_TAG_LENGTH;
+			target =
+				(hasAggro ? '*' : "") +
+					(isTarget ? attackingColTag :
+						player ? ColorUtil.colorStartTag(0xffffff) : ColorUtil.colorStartTag(0xffff00)) +
+					target.substring(start);
+		}
+		else if (aggroChanged)
+		{
+			if (hasAggro)
+			{
+				target = '*' + target;
+			}
+			else
+			{
+				target = target.substring(1);
+			}
+		}
+
+		if (hpChanged || hasHp)
+		{
+			final int braceIdx;
+
+			if (!hasHp)
+			{
+				braceIdx = target.lastIndexOf("<col=ff0000>(");
+				if (braceIdx != -1)
+				{
+					target = target.substring(0, braceIdx - 1) + "(level-" + actor.getCombatLevel() + ")";
+				}
+			}
+			else if ((braceIdx = target.lastIndexOf('(')) != -1)
+			{
+				final String hpString = getHpString(actor, hpChanged);
+
+				target = target.substring(0, braceIdx) + hpString;
+			}
+		}
+
+		entry.setTarget(target);
+		return true;
+	}
+
+	private boolean isNotAttackEntry(MenuEntry entry)
+	{
+		return entry.getOpcode() != MenuOpcode.NPC_SECOND_OPTION.getId() &&
+			entry.getOpcode() != menuManager.getPlayerAttackOpcode()
+			|| !entry.getOption().equals("Attack");
+	}
+
+	private String getHpString(Actor actor, boolean withColorTag)
+	{
+		int maxHp = getMaxHp(actor);
+		int health = actor.getHealth();
+		int ratio = actor.getHealthRatio();
+
+		final String result;
+		if (maxHp != -1)
+		{
+			final int exactHealth = OpponentInfoOverlay.getExactHp(ratio, health, maxHp);
+			result = "(" + exactHealth + "/" + maxHp + ")";
+		}
+		else
+		{
+			result = "(" + (100 * ratio) / health + "%)";
+		}
+
+		return withColorTag ? ColorUtil.colorStartTag(0xff0000) + result : result;
+	}
+
+	int getMaxHp(Actor actor)
+	{
+		if (actor instanceof NPC)
+		{
+			return npcManager.getHealth(((NPC) actor).getId());
+		}
+		else
+		{
+			final HiscoreResult hiscoreResult = hiscoreManager.lookupAsync(Text.removeTags(actor.getName()), getHiscoreEndpoint());
+			if (hiscoreResult != null)
+			{
+				final int hp = hiscoreResult.getHitpoints().getLevel();
+				if (hp > 0)
+				{
+					return hp;
+				}
+			}
+
+			return -1;
+		}
+	}
+
+	private Actor getActorFromIndex(int index)
+	{
+		if (index < 32768)
+		{
+			return client.getCachedNPCs()[index];
+		}
+		else
+		{
+			return client.getCachedPlayers()[index - 32768];
+		}
+	}
+}

--- a/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/HitpointsDisplayStyle.java
+++ b/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/HitpointsDisplayStyle.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019, Sean Dewar <https://github.com/seandewar>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.betteropponentinfo;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum HitpointsDisplayStyle
+{
+	HITPOINTS("Hitpoints"),
+	PERCENTAGE("Percentage"),
+	BOTH("Both");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/OpponentInfoOverlay.java
+++ b/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/OpponentInfoOverlay.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2016-2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.betteropponentinfo;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import javax.inject.Inject;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY_CONFIG;
+import net.runelite.api.Varbits;
+import net.runelite.api.util.Text;
+import net.runelite.client.ui.overlay.Overlay;
+import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.ComponentConstants;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.ProgressBarComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.api.Varbits;
+
+class OpponentInfoOverlay extends Overlay
+{
+	private static final Color HP_GREEN = new Color(0, 146, 54, 230);
+	private static final Color HP_RED = new Color(102, 15, 16, 230);
+
+	private final Client client;
+	private final BetterOpponentInfoPlugin opponentInfoPlugin;
+	private final BetterOpponentInfoConfig opponentInfoConfig;
+	private String opponentsOpponentName;
+
+	private final PanelComponent panelComponent = new PanelComponent();
+
+	private int lastMaxHealth;
+	private int lastRatio = 0;
+	private int lastHealthScale = 0;
+	private String opponentName;
+
+	@Inject
+	private OpponentInfoOverlay(
+		final Client client,
+		final BetterOpponentInfoPlugin opponentInfoPlugin,
+		final BetterOpponentInfoConfig opponentInfoConfig)
+	{
+		super(opponentInfoPlugin);
+		this.client = client;
+		this.opponentInfoPlugin = opponentInfoPlugin;
+		this.opponentInfoConfig = opponentInfoConfig;
+
+		setPosition(OverlayPosition.TOP_LEFT);
+		setPriority(OverlayPriority.HIGH);
+
+		panelComponent.setBorder(new Rectangle(2, 2, 2, 2));
+		panelComponent.setGap(new Point(0, 2));
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Opponent info overlay"));
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		final Actor opponent = opponentInfoPlugin.getLastOpponent();
+
+		if (opponent == null)
+		{
+			opponentName = null;
+			return null;
+		}
+
+		if (opponent.getName() != null && opponent.getHealth() > 0)
+		{
+			lastRatio = opponent.getHealthRatio();
+			lastHealthScale = opponent.getHealth();
+			opponentName = Text.removeTags(opponent.getName());
+
+			lastMaxHealth = opponentInfoPlugin.getMaxHp(opponent);
+
+			final Actor opponentsOpponent = opponent.getInteracting();
+			if (opponentsOpponent != null
+				&& (opponentsOpponent != client.getLocalPlayer() || client.getVar(Varbits.MULTICOMBAT_AREA) == 1))
+			{
+				opponentsOpponentName = Text.removeTags(opponentsOpponent.getName());
+			}
+			else
+			{
+				opponentsOpponentName = null;
+			}
+
+		}
+
+		if (opponentName == null)
+		{
+			return null;
+		}
+
+		final FontMetrics fontMetrics = graphics.getFontMetrics();
+
+		panelComponent.getChildren().clear();
+
+		// Opponent name
+		int textWidth = Math.max(ComponentConstants.STANDARD_WIDTH, fontMetrics.stringWidth(opponentName));
+		panelComponent.setPreferredSize(new Dimension(textWidth, 0));
+		panelComponent.getChildren().add(TitleComponent.builder()
+			.text(opponentName)
+			.build());
+
+		// Health bar
+		if (lastRatio >= 0 && lastHealthScale > 0)
+		{
+			final ProgressBarComponent progressBarComponent = new ProgressBarComponent();
+			progressBarComponent.setBackgroundColor(HP_RED);
+			progressBarComponent.setForegroundColor(HP_GREEN);
+
+			final HitpointsDisplayStyle displayStyle = opponentInfoConfig.hitpointsDisplayStyle();
+
+			if ((displayStyle == HitpointsDisplayStyle.HITPOINTS || displayStyle == HitpointsDisplayStyle.BOTH)
+				&& lastMaxHealth != -1)
+			{
+				int health = getExactHp(lastRatio, lastHealthScale, lastMaxHealth);
+
+				// Show both the hitpoint and percentage values if enabled in the config
+				final ProgressBarComponent.LabelDisplayMode progressBarDisplayMode = displayStyle == HitpointsDisplayStyle.BOTH ?
+					ProgressBarComponent.LabelDisplayMode.BOTH : ProgressBarComponent.LabelDisplayMode.FULL;
+
+				progressBarComponent.setLabelDisplayMode(progressBarDisplayMode);
+				progressBarComponent.setMaximum(lastMaxHealth);
+				progressBarComponent.setValue(health);
+			}
+			else
+			{
+				float floatRatio = (float) lastRatio / (float) lastHealthScale;
+				progressBarComponent.setValue(floatRatio * 100d);
+			}
+
+			panelComponent.getChildren().add(progressBarComponent);
+		}
+		// Opponents opponent
+		if (opponentsOpponentName != null && opponentInfoConfig.showOpponentsOpponent())
+		{
+			textWidth = Math.max(textWidth, fontMetrics.stringWidth(opponentsOpponentName));
+			panelComponent.setPreferredSize(new Dimension(textWidth, 0));
+			panelComponent.getChildren().add(TitleComponent.builder()
+					.text(opponentsOpponentName)
+					.build());
+		}
+
+		return panelComponent.render(graphics);
+	}
+
+	static int getExactHp(int ratio, int health, int maxHp)
+	{
+		if (ratio < 0 || health <= 0 || maxHp == -1)
+		{
+			return -1;
+		}
+
+		int exactHealth = 0;
+
+		// This is the reverse of the calculation of healthRatio done by the server
+		// which is: healthRatio = 1 + (healthScale - 1) * health / maxHealth (if health > 0, 0 otherwise)
+		// It's able to recover the exact health if maxHealth <= healthScale.
+		if (ratio > 0)
+		{
+			int minHealth = 1;
+			int maxHealth;
+			if (health > 1)
+			{
+				if (ratio > 1)
+				{
+					// This doesn't apply if healthRatio = 1, because of the special case in the server calculation that
+					// health = 0 forces healthRatio = 0 instead of the expected healthRatio = 1
+					minHealth = (maxHp * (ratio - 1) + health - 2) / (health - 1);
+				}
+				maxHealth = (maxHp * ratio - 1) / (health - 1);
+				if (maxHealth > maxHp)
+				{
+					maxHealth = maxHp;
+				}
+			}
+			else
+			{
+				// If healthScale is 1, healthRatio will always be 1 unless health = 0
+				// so we know nothing about the upper limit except that it can't be higher than maxHealth
+				maxHealth = maxHp;
+			}
+			// Take the average of min and max possible healths
+			exactHealth = (minHealth + maxHealth + 1) / 2;
+		}
+
+		return exactHealth;
+	}
+}

--- a/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/PlayerComparisonOverlay.java
+++ b/betteropponentinfo/src/main/java/net/runelite/client/plugins/betteropponentinfo/PlayerComparisonOverlay.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.betteropponentinfo;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY_CONFIG;
+import net.runelite.api.Player;
+import net.runelite.api.Skill;
+import net.runelite.api.util.Text;
+import net.runelite.client.game.HiscoreManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.ui.overlay.components.table.TableAlignment;
+import net.runelite.client.ui.overlay.components.table.TableComponent;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.http.api.hiscore.HiscoreResult;
+import net.runelite.http.api.hiscore.HiscoreSkill;
+
+class PlayerComparisonOverlay extends Overlay
+{
+	private static final Color HIGHER_STAT_TEXT_COLOR = Color.GREEN;
+	private static final Color LOWER_STAT_TEXT_COLOR = Color.RED;
+	private static final Color NEUTRAL_TEXT_COLOR = Color.WHITE;
+	private static final Color HIGHLIGHT_COLOR = new Color(255, 200, 0, 255);
+
+	private static final Skill[] COMBAT_SKILLS = new Skill[]{
+		Skill.ATTACK,
+		Skill.STRENGTH,
+		Skill.DEFENCE,
+		Skill.HITPOINTS,
+		Skill.RANGED,
+		Skill.MAGIC,
+		Skill.PRAYER
+	};
+
+	private static final HiscoreSkill[] HISCORE_COMBAT_SKILLS = new HiscoreSkill[]{
+		HiscoreSkill.ATTACK,
+		HiscoreSkill.STRENGTH,
+		HiscoreSkill.DEFENCE,
+		HiscoreSkill.HITPOINTS,
+		HiscoreSkill.RANGED,
+		HiscoreSkill.MAGIC,
+		HiscoreSkill.PRAYER
+	};
+
+	private static final String SKILL_COLUMN_HEADER = "Skill";
+	private static final String PLAYER_COLUMN_HEADER = "You";
+	private static final String OPPONENT_COLUMN_HEADER = "Them";
+
+	private final Client client;
+	private final BetterOpponentInfoPlugin opponentInfoPlugin;
+	private final BetterOpponentInfoConfig opponentInfoConfig;
+	private final HiscoreManager hiscoreManager;
+	private final PanelComponent panelComponent = new PanelComponent();
+
+	@Inject
+	private PlayerComparisonOverlay(final Client client, final BetterOpponentInfoPlugin opponentInfoPlugin, final BetterOpponentInfoConfig opponentInfoConfig, final HiscoreManager hiscoreManager)
+	{
+		super(opponentInfoPlugin);
+		this.client = client;
+		this.opponentInfoPlugin = opponentInfoPlugin;
+		this.opponentInfoConfig = opponentInfoConfig;
+		this.hiscoreManager = hiscoreManager;
+
+		setPosition(OverlayPosition.BOTTOM_LEFT);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Opponent info overlay"));
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!opponentInfoConfig.lookupOnInteraction())
+		{
+			return null;
+		}
+
+		final Actor opponent = opponentInfoPlugin.getLastOpponent();
+
+		if (opponent == null)
+		{
+			return null;
+		}
+
+		// Don't try to look up NPC names
+		if (!(opponent instanceof Player))
+		{
+			return null;
+		}
+
+		final String opponentName = Text.removeTags(opponent.getName());
+		final HiscoreResult hiscoreResult = hiscoreManager.lookupAsync(opponentName, opponentInfoPlugin.getHiscoreEndpoint());
+		if (hiscoreResult == null)
+		{
+			return null;
+		}
+
+		panelComponent.getChildren().clear();
+		generateComparisonTable(panelComponent, hiscoreResult);
+		return panelComponent.render(graphics);
+	}
+
+	private void generateComparisonTable(PanelComponent panelComponent, HiscoreResult opponentSkills)
+	{
+		final String opponentName = opponentSkills.getPlayer();
+
+		panelComponent.getChildren().add(
+			TitleComponent.builder()
+				.text(opponentName)
+				.color(HIGHLIGHT_COLOR)
+				.build());
+
+		TableComponent tableComponent = new TableComponent();
+		tableComponent.setColumnAlignments(TableAlignment.LEFT, TableAlignment.CENTER, TableAlignment.RIGHT);
+		tableComponent.addRow(
+			ColorUtil.prependColorTag(SKILL_COLUMN_HEADER, HIGHLIGHT_COLOR),
+			ColorUtil.prependColorTag(PLAYER_COLUMN_HEADER, HIGHLIGHT_COLOR),
+			ColorUtil.prependColorTag(OPPONENT_COLUMN_HEADER, HIGHLIGHT_COLOR));
+
+		for (int i = 0; i < COMBAT_SKILLS.length; ++i)
+		{
+			final HiscoreSkill hiscoreSkill = HISCORE_COMBAT_SKILLS[i];
+			final Skill skill = COMBAT_SKILLS[i];
+
+			final net.runelite.http.api.hiscore.Skill opponentSkill = opponentSkills.getSkill(hiscoreSkill);
+
+			if (opponentSkill == null || opponentSkill.getLevel() == -1)
+			{
+				continue;
+			}
+
+			final int playerSkillLevel = client.getRealSkillLevel(skill);
+			final int opponentSkillLevel = opponentSkill.getLevel();
+
+			tableComponent.addRow(
+				hiscoreSkill.getName(),
+				ColorUtil.prependColorTag(Integer.toString(playerSkillLevel), comparisonStatColor(playerSkillLevel, opponentSkillLevel)),
+				ColorUtil.prependColorTag(Integer.toString(opponentSkillLevel), comparisonStatColor(opponentSkillLevel, playerSkillLevel)));
+		}
+
+		panelComponent.getChildren().add(tableComponent);
+	}
+
+	private static Color comparisonStatColor(int a, int b)
+	{
+		if (a > b)
+		{
+			return HIGHER_STAT_TEXT_COLOR;
+		}
+		if (a < b)
+		{
+			return LOWER_STAT_TEXT_COLOR;
+		}
+		return NEUTRAL_TEXT_COLOR;
+	}
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ rootProject.name = "xKylee Plugins"
 
 include(":alchemicalhydra")
 include(":aoewarnings")
+include(":betteropponentinfo")
 include(":blackjack")
 include(":cerberus")
 include(":clanmanmode")


### PR DESCRIPTION
re-adds who the NPC is targeting when in multi combat

can cause conflict if the compliant opponentinfo is enabled (dupe overlays) - not sure how to handle that