### PR TITLE
inferno: add option to always show prayer helper

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.3"
+version = "0.0.4"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
@@ -247,6 +247,18 @@ public interface InfernoConfig extends Config
 
 	@ConfigItem(
 		position = 4,
+		keyName = "alwaysShowPrayerHelper",
+		name = "Always Show Prayer Helper",
+		description = "Render prayer helper at all time, even when other inventory tabs are open.",
+		section = "PrayerSection"
+	)
+	default boolean alwaysShowPrayerHelper()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 4,
 		keyName = "safespotDisplayMode",
 		name = "Tile Safespots",
 		description = "Indicate safespots on the ground: safespot (white), pray melee (red), pray range (green), pray magic (blue) and combinations of those",

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
-
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.Perspective;

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
+
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.Perspective;
@@ -125,11 +126,17 @@ public class InfernoOverlay extends Overlay
 			}
 		}
 
+		var prayerWidgetHidden =
+			meleePrayerWidget == null
+				|| rangePrayerWidget == null
+				|| magicPrayerWidget == null
+				|| meleePrayerWidget.isHidden()
+				|| rangePrayerWidget.isHidden()
+				|| magicPrayerWidget.isHidden();
+
 		if ((config.prayerDisplayMode() == InfernoPrayerDisplayMode.PRAYER_TAB
 			|| config.prayerDisplayMode() == InfernoPrayerDisplayMode.BOTH)
-			&& (meleePrayerWidget != null && !meleePrayerWidget.isHidden()
-			&& rangePrayerWidget != null && !rangePrayerWidget.isHidden()
-			&& magicPrayerWidget != null && !magicPrayerWidget.isHidden()))
+			&& (!prayerWidgetHidden || config.alwaysShowPrayerHelper()))
 		{
 			renderPrayerIconOverlay(graphics);
 


### PR DESCRIPTION
I have added an option to always show the prayer helper even when the prayer widget is hidden.
This is defaulted to `false` as to keep the old functionality as the default.
Here's an exmaple: https://gyazo.com/20ac9a6fc6865490b594a370ab4bb8b0.

It seems that `getWidget` will return `null` upon login, until you open the prayer widget once.
On login players will have to open the prayer widget once and then the helper will never be hidden.
