### PR TITLE
nightmare: add parasite tick timer option

### DIFF
--- a/nightmare/nightmare.gradle.kts
+++ b/nightmare/nightmare.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.8"
+version = "0.0.9"
 
 project.extra["PluginName"] = "Nightmare of Ashihama"
 project.extra["PluginDescription"] = "Shows what to pray and what to do at Nightmare of Ashihama"

--- a/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmareConfig.java
+++ b/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmareConfig.java
@@ -130,4 +130,16 @@ public interface NightmareConfig extends Config
 	{
 		return new Color(255, 0, 0, 50);
 	}
+
+	@ConfigItem(
+		keyName = "showTicksUntilParasite",
+		name = "Indicate Parasites",
+		description = "Displays a red tick timer on you showing if/when a parasite will emerge",
+		position = 7,
+		titleSection = "generalSection"
+	)
+	default boolean showTicksUntilParasite()
+	{
+		return true;
+	}
 }

--- a/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmareOverlay.java
+++ b/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmareOverlay.java
@@ -120,6 +120,17 @@ class NightmareOverlay extends Overlay
 			renderTextLocation(graphics, str, 20, Font.BOLD, tickColor, point);
 		}
 
+		int ticksUntilNextParasite = plugin.getTicksUntilParasite();
+		if (config.showTicksUntilParasite() && ticksUntilNextParasite > 0)
+		{
+			String str = Integer.toString(ticksUntilNextParasite);
+
+			LocalPoint lp = client.getLocalPlayer().getLocalLocation();
+			Point point = Perspective.getCanvasTextLocation(client, graphics, lp, str, 0);
+
+			renderTextLocation(graphics, str, 14, Font.BOLD, Color.RED, point);
+		}
+
 		if (config.highlightTotems())
 		{
 			for (MemorizedTotem totem : plugin.getTotems().values())

--- a/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmarePlugin.java
+++ b/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmarePlugin.java
@@ -21,6 +21,8 @@ import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.NpcDefinitionChanged;
 import net.runelite.client.config.ConfigManager;
@@ -100,6 +102,9 @@ public class NightmarePlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private int ticksUntilNextAttack = 0;
 
+	@Getter(AccessLevel.PACKAGE)
+	private int ticksUntilParasite = 0;
+
 	public NightmarePlugin()
 	{
 		inFight = false;
@@ -138,6 +143,7 @@ public class NightmarePlugin extends Plugin
 		cursed = false;
 		attacksSinceCurse = 0;
 		ticksUntilNextAttack = 0;
+		ticksUntilParasite = 0;
 		totems.clear();
 		spores.clear();
 	}
@@ -225,6 +231,21 @@ public class NightmarePlugin extends Plugin
 	}
 
 	@Subscribe
+	private void onChatMessage(ChatMessage chatMessage)
+	{
+		if (!inFight || chatMessage.getType() != ChatMessageType.GAMEMESSAGE)
+		{
+			return;
+		}
+
+		final String message = chatMessage.getMessage();
+		if (message.contains("The Nightmare has impregnated you with a deadly parasite!"))
+		{
+			ticksUntilParasite = 22;
+		}
+	}
+
+	@Subscribe
 	public void onNpcDefinitionChanged(NpcDefinitionChanged event)
 	{
 		final NPC npc = event.getNpc();
@@ -289,6 +310,11 @@ public class NightmarePlugin extends Plugin
 		}
 
 		ticksUntilNextAttack--;
+
+		if (ticksUntilParasite > 0)
+		{
+			ticksUntilParasite--;
+		}
 
 		if (pendingNightmareAttack != null && ticksUntilNextAttack <= 3)
 		{


### PR DESCRIPTION
This PR adds the option for a basic red tick timer to display on the current player if they have been infected by a parasite during the nightmare fight. Features:

- Will start to count down from 21 ticks if the user has been infected by a parasite, with the ticks drawn on the player.
- Will end when the parasite has spawned.

A fancier method for showing the countdown until parasite spawn (as mentioned in #53) is entirely possible, but I will have to leave it for someone else who is better with making those kinds of overlays.