### PR TITLE
inferno: add inferno shield predict and live plus predict options

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.4"
+version = "0.0.5"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
@@ -924,7 +924,7 @@ public interface InfernoConfig extends Config
 		position = 1,
 		keyName = "safespotsZukShieldBeforeHealers",
 		name = "Safespots (Before Healers)",
-		description = "Indicate the zuk shield safespots. 'Tile Safespots' in the 'Safespots' category needs to be turned on for this to take effect.",
+		description = "Indicate the zuk shield safespots. 'Tile Safespots' in the 'Safespots' category needs to be turned on for this to take effect. Shield must go back and forth at least 1 time before the predict option will work.",
 		section = "ZukSection"
 	)
 	default InfernoZukShieldDisplayMode safespotsZukShieldBeforeHealers()
@@ -941,7 +941,7 @@ public interface InfernoConfig extends Config
 	)
 	default InfernoZukShieldDisplayMode safespotsZukShieldAfterHealers()
 	{
-		return InfernoZukShieldDisplayMode.LIVE;
+		return InfernoZukShieldDisplayMode.LIVEPLUSPREDICT;
 	}
 
 	@ConfigItem(

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
@@ -941,7 +941,7 @@ public interface InfernoConfig extends Config
 	)
 	default InfernoZukShieldDisplayMode safespotsZukShieldAfterHealers()
 	{
-		return InfernoZukShieldDisplayMode.LIVEPLUSPREDICT;
+		return InfernoZukShieldDisplayMode.LIVE;
 	}
 
 	@ConfigItem(

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/displaymodes/InfernoZukShieldDisplayMode.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/displaymodes/InfernoZukShieldDisplayMode.java
@@ -8,7 +8,8 @@ public enum InfernoZukShieldDisplayMode
 {
 	OFF("Off"),
 	LIVE("Live (follow shield)"),
-	PREDICT("Predict (NOT WORKING YET)");
+	PREDICT("Predict"),
+	LIVEPLUSPREDICT("Live and Predict");
 
 	final private String name;
 


### PR DESCRIPTION
This PR implements the inferno shield predict and live + predict options. As indicated in the config description, the predicted shield will only start showing once the shield has moved one complete rotation because of the way the predicted safespots are calculated.