### PR TITLE
inferno: improve shield prediction accuracy

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.6"
+version = "0.0.7"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoNPC.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoNPC.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import net.runelite.api.AnimationID;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
@@ -49,6 +50,7 @@ class InfernoNPC
 	@Getter(AccessLevel.PACKAGE)
 	private Attack nextAttack;
 	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
 	private int ticksTillNextAttack;
 	private int lastAnimation;
 	private boolean lastCanAttack;

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -278,6 +278,15 @@ public class InfernoPlugin extends Plugin
 		{
 			log.debug("[INFERNO] Final phase detected!");
 			finalPhase = true;
+
+			//decrement ticksTilNextAttack by 3
+			for (InfernoNPC infernoNPC : infernoNpcs)
+			{
+				if (infernoNPC.getType() == InfernoNPC.Type.ZUK)
+				{
+					infernoNPC.setTicksTillNextAttack(infernoNPC.getTicksTillNextAttack() - 3);
+				}
+			}
 		}
 
 		// Blobs need to be added to the end of the list because the prayer for their detection tick will be based
@@ -713,6 +722,11 @@ public class InfernoPlugin extends Plugin
 				if (infernoNPC.getType() == InfernoNPC.Type.ZUK)
 				{
 					int ticksTilZukAttack = infernoNPC.getTicksTillNextAttack() - 1;
+
+					if (ticksTilZukAttack < 0)
+					{
+						ticksTilZukAttack = 0;
+					}
 
 					//if the ticksTilZukAttack == 0, start to render the next safespot, as it is safe to start moving there
 					if (ticksTilZukAttack < 1)


### PR DESCRIPTION
There was an issue where the predicted safespot might be a little bit off immediately after the healers spawned. While this would correct itself within 1-2 Zuk attacks, it could cause the user to stand in the wrong spot and take a hit from Zuk. This PR should mitigate that issue.