### PR TITLE
inferno: improve predicted shield accuracy

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.7"
+version = "0.0.8"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -721,7 +721,7 @@ public class InfernoPlugin extends Plugin
 			{
 				if (infernoNPC.getType() == InfernoNPC.Type.ZUK)
 				{
-					int ticksTilZukAttack = infernoNPC.getTicksTillNextAttack() - 1;
+					int ticksTilZukAttack = infernoNPC.getTicksTillNextAttack();
 
 					if (ticksTilZukAttack < 0)
 					{
@@ -731,7 +731,7 @@ public class InfernoPlugin extends Plugin
 					//if the ticksTilZukAttack == 0, start to render the next safespot, as it is safe to start moving there
 					if (ticksTilZukAttack < 1)
 					{
-						ticksTilZukAttack = 7;
+						ticksTilZukAttack = finalPhase ? 7 : 10;
 					}
 
 					//if zuk shield moving in positive direction


### PR DESCRIPTION
While doing additional testing of the inferno predicted shield, I discovered that Zuk decides whether or not to target you when the tick counter hits "7" (after healers) or "10" (before healers), not "1" as is commonly assumed. I have modified the predicted safespot calculations accordingly.