### PR TITLE
inferno: improve pre-healers predicted safespot accuracy

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.12"
+version = "0.0.13"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -807,12 +807,20 @@ public class InfernoPlugin extends Plugin
 			{
 				if (infernoNPC.getType() == InfernoNPC.Type.ZUK)
 				{
-					int ticksTilZukAttack = infernoNPC.getTicksTillNextAttack();
+					int ticksTilZukAttack = finalPhase ? infernoNPC.getTicksTillNextAttack() : infernoNPC.getTicksTillNextAttack() - 1;
 
-					//if ticksTilZukAttack < 1, must be due to finalPhase. don't render predicted safespot
 					if (ticksTilZukAttack < 1)
 					{
-						return;
+						if (finalPhase)
+						{
+							//if ticksTilZukAttack < 1 and finalPhase, must be due to finalPhase. don't render predicted safepot until next attack.
+							return;
+						}
+						else
+						{
+							//safe to start to render the next safespot
+							ticksTilZukAttack = 10;
+						}
 					}
 
 					//if zuk shield moving in positive direction


### PR DESCRIPTION
Shifted the pre-healers predicted safespot behind by 1 tile, which should now make it 100% accurate when it is shown. This is because Zuk attacks when the counter says "1" pre-healers, but "7" post-healers. Thanks to @dutta64 for the heads up about this.