### PR TITLE
inferno: handle timer re-pausing edge case

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.13"
+version = "0.0.14"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -325,6 +325,12 @@ public class InfernoPlugin extends Plugin
 					spawnTimerInfoBox.run();
 				}
 				break;
+			case JAD:
+				if (zuk != null && spawnTimerInfoBox != null && !spawnTimerInfoBox.isRunning())
+				{
+					spawnTimerInfoBox.run();
+				}
+				break;
 			case ZUK:
 				finalPhase = false;
 				zukShieldCornerTicks = -2;

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoSpawnTimerInfobox.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoSpawnTimerInfobox.java
@@ -45,11 +45,14 @@ class InfernoSpawnTimerInfobox extends InfoBox
 	@Getter(AccessLevel.PACKAGE)
 	private boolean running;
 
+	private boolean pausedOnce;
+
 	InfernoSpawnTimerInfobox(final BufferedImage image, final InfernoPlugin plugin)
 	{
 		super(image, plugin);
 		setPriority(InfoBoxPriority.HIGH);
 		running = false;
+		pausedOnce = false;
 		timeRemaining = SPAWN_DURATION;
 	}
 
@@ -67,12 +70,13 @@ class InfernoSpawnTimerInfobox extends InfoBox
 
 	void pause()
 	{
-		if (!running)
+		if (!running || pausedOnce)
 		{
 			return;
 		}
 
 		running = false;
+		pausedOnce = true;
 
 		long timeElapsed = Instant.now().getEpochSecond() - startTime;
 


### PR DESCRIPTION
If the player hits Zuk to exactly 479 hp there is a chance that calculateNpcHp does not report the exact hp and the timer never unpauses. There is also the possibility that Zuk regens to 480 hp naturally and the timer re-pauses. This commit should handle this edge case.

There is another edge case where the player hits Zuk to 599 hp and calculateNpcHp does not report the correct Hp and thus the timer never pauses. Can't think of a way to handle this unless hp can be calculated exactly.