### PR TITLE
lizardman shamans: add increased radius support

### DIFF
--- a/lizardmenshaman/lizardmenshaman.gradle.kts
+++ b/lizardmenshaman/lizardmenshaman.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.6"
+version = "0.0.7"
 
 project.extra["PluginName"] = "Lizard Shamans"
 project.extra["PluginDescription"] = "Configures timer for lizardmen shaman spawns"


### PR DESCRIPTION
This adds support for shaman spawns in the canyon location, which had an increased explosion radius compared to molch dungeon/temple (5x5 vs 3x3).