### PR TITLE
inferno: hide predicted safespots post-healers until ticksTillNextAttack is synced

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.13"
+version = "0.0.14"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -351,7 +351,7 @@ public class InfernoPlugin extends Plugin
 				{
 					if (infernoNPC.getType() == InfernoNPC.Type.ZUK)
 					{
-						infernoNPC.setTicksTillNextAttack(infernoNPC.getTicksTillNextAttack() - 3);
+						infernoNPC.setTicksTillNextAttack(infernoNPC.getTicksTillNextAttack() - 10);
 					}
 				}
 				log.debug("[INFERNO] Final phase detected!");


### PR DESCRIPTION
Immediately after healers spawn, the ticksTillNextAttack is not accurate. By setting it to a negative va;ie, it will be allowed to update immediately after the next Zuk attack animation, and it won't render the predicted safespot until it is 100% sure of where it is safe.