### PR TITLE
sepulchre: expand crossbow statue de-highlight cases

### DIFF
--- a/hallowedsepulchre/hallowedsepulchre.gradle.kts
+++ b/hallowedsepulchre/hallowedsepulchre.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.14"
+version = "0.0.15"
 
 project.extra["PluginName"] = "Hallowed Sepulchre"
 project.extra["PluginDescription"] = "Hallowed Sepulchre"

--- a/hallowedsepulchre/src/main/java/net/runelite/client/plugins/hallowedsepulchre/HallowedSepulchreOverlay.java
+++ b/hallowedsepulchre/src/main/java/net/runelite/client/plugins/hallowedsepulchre/HallowedSepulchreOverlay.java
@@ -27,6 +27,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 public class HallowedSepulchreOverlay extends Overlay
 {
 	private static final int CROSSBOW_STATUE_ANIM_DEFAULT = 8681;
+	private static final int CROSSBOW_STATUE_ANIM_FINAL = 8685;
 
 	private final Client client;
 	private final HallowedSepulchrePlugin plugin;
@@ -175,7 +176,7 @@ public class HallowedSepulchreOverlay extends Overlay
 
 			final DynamicObject dynamicObject = (DynamicObject) gameObject.getEntity();
 
-			if (dynamicObject.getAnimationID() == CROSSBOW_STATUE_ANIM_DEFAULT)
+			if (dynamicObject.getAnimationID() == CROSSBOW_STATUE_ANIM_DEFAULT || dynamicObject.getAnimationID() == CROSSBOW_STATUE_ANIM_FINAL)
 			{
 				continue;
 			}


### PR DESCRIPTION
There's a slight bug where the crossbow statue would get stuck and stay highlighted even when it was done firing, it appears to be due to gameObject animationIds not updating properly if the statue is too far away. This PR should mitigate that issue without negatively impacting the experience, since the projectile will have left the statue already by the time the statue is de-highlighted.