### PR TITLE
socket: fix socket config

### DIFF
--- a/socketplayerstatus/socketplayerstatus.gradle.kts
+++ b/socketplayerstatus/socketplayerstatus.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.1"
+version = "0.0.2"
 
 project.extra["PluginName"] = "Socket Player Status"
 project.extra["PluginDescription"] = "Socket extension for displaying player status to members in your party."

--- a/socketplayerstatus/src/main/java/net/runelite/client/plugins/socketplayerstatus/PlayerStatusConfig.java
+++ b/socketplayerstatus/src/main/java/net/runelite/client/plugins/socketplayerstatus/PlayerStatusConfig.java
@@ -117,7 +117,7 @@ public interface PlayerStatusConfig extends Config
 	)
 	default boolean showOverload()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
No idea why I left overload timers visible. People are confused where it comes from.

Updates default config for new installations.