### PR TITLE
inferno: wait 3 ticks after healers spawn before setting predicted safespot

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.15"
+version = "0.0.16"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoNPC.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoNPC.java
@@ -173,7 +173,7 @@ class InfernoNPC
 		return new WorldArea(lastPlayerLocation, 1, 1).hasLineOfSightTo(client, this.getNpc().getWorldArea());
 	}
 
-	void gameTick(Client client, WorldPoint lastPlayerLocation, boolean finalPhase, boolean finalPhaseTick)
+	void gameTick(Client client, WorldPoint lastPlayerLocation, boolean finalPhase, int ticksSinceFinalPhase)
 	{
 		safeSpotCache.clear();
 
@@ -198,12 +198,15 @@ class InfernoNPC
 			switch (this.getType())
 			{
 				case ZUK:
-					//if final phase started on this exact tick, skip setting the ticksTillNextAttack
-					if (this.getNpc().getAnimation() == AnimationID.TZKAL_ZUK && !finalPhaseTick)
+					if (this.getNpc().getAnimation() == AnimationID.TZKAL_ZUK)
 					{
 						if (finalPhase)
 						{
-							this.updateNextAttack(this.getType().getDefaultAttack(), 7);
+							//if on final phase, wait until at least 3 ticks since the final phase started to set the ticksTilNextAttack
+							if (ticksSinceFinalPhase > 3)
+							{
+								this.updateNextAttack(this.getType().getDefaultAttack(), 7);
+							}
 						}
 						else
 						{

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -130,6 +130,7 @@ public class InfernoPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private boolean finalPhase = false;
 	private boolean finalPhaseTick = false;
+	private int ticksSinceFinalPhase = 0;
 	@Getter(AccessLevel.PACKAGE)
 	private NPC zukShield = null;
 	private NPC zuk = null;
@@ -288,10 +289,14 @@ public class InfernoPlugin extends Plugin
 
 		calculateSpawnTimerInfobox();
 
-		//no longer on the same tick that finalPhase started
+		//if finalPhaseTick, we will skip incrementing because we already did it in onNpcSpawned
 		if (finalPhaseTick)
 		{
 			finalPhaseTick = false;
+		}
+		else if(finalPhase)
+		{
+			ticksSinceFinalPhase++;
 		}
 	}
 
@@ -354,6 +359,7 @@ public class InfernoPlugin extends Plugin
 				break;
 			case HEALER_ZUK:
 				finalPhase = true;
+				ticksSinceFinalPhase++;
 				finalPhaseTick = true;
 				for (InfernoNPC infernoNPC : infernoNpcs)
 				{
@@ -498,7 +504,7 @@ public class InfernoPlugin extends Plugin
 	{
 		for (InfernoNPC infernoNPC : infernoNpcs)
 		{
-			infernoNPC.gameTick(client, lastLocation, finalPhase, finalPhaseTick);
+			infernoNPC.gameTick(client, lastLocation, finalPhase, ticksSinceFinalPhase);
 
 			if (infernoNPC.getType() == InfernoNPC.Type.ZUK && zukShieldCornerTicks == -1)
 			{

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -294,7 +294,7 @@ public class InfernoPlugin extends Plugin
 		{
 			finalPhaseTick = false;
 		}
-		else if(finalPhase)
+		else if (finalPhase)
 		{
 			ticksSinceFinalPhase++;
 		}

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -359,7 +359,7 @@ public class InfernoPlugin extends Plugin
 				break;
 			case HEALER_ZUK:
 				finalPhase = true;
-				ticksSinceFinalPhase++;
+				ticksSinceFinalPhase = 1;
 				finalPhaseTick = true;
 				for (InfernoNPC infernoNPC : infernoNpcs)
 				{


### PR DESCRIPTION
By waiting 3 ticks after healers spawn to set the predicted safespot, the edge case where the predicted safespots (and tick counter) becomes messed up if the healers spawn on or around the same tick that Zuk attacks can be avoided.

Unfortunately, this does result in a slightly longer delay before you are able to use the predicted safespots post-healers, but I believe it is necessary because it should properly handle all cases (instead of handling most cases well, and some cases badly like it did before). It might be possible to get the best of both worlds with some additional adjustments, but that will have to be for another PR.