### PR TITLE
SorceressGarden: Add plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,6 +65,7 @@ include(":socket")
 include(":socketplayerstatus")
 include(":socketsotetseg")
 include(":socketspecialcounter")
+include(":sorceressgarden")
 include(":specbar")
 include(":specorb")
 include(":spellbook")
@@ -89,4 +90,4 @@ for (project in rootProject.children) {
         require(buildFile.isFile) { "Project '${project.path} must have a $buildFile build script" }
     }
 }
-
+include("sorceressgarden")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -90,4 +90,3 @@ for (project in rootProject.children) {
         require(buildFile.isFile) { "Project '${project.path} must have a $buildFile build script" }
     }
 }
-include("sorceressgarden")

--- a/sorceressgarden/sorceressgarden.gradle.kts
+++ b/sorceressgarden/sorceressgarden.gradle.kts
@@ -1,0 +1,61 @@
+import ProjectVersions.rlVersion
+
+/*
+ * Copyright (c) 2019 Owain van Brakel <https://github.com/Owain94>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+version = "0.0.1"
+
+project.extra["PluginName"] = "Sorceress' Garden"
+project.extra["PluginDescription"] = "Provides various utilities for the Sorceress' Garden minigame"
+
+dependencies {
+    annotationProcessor(Libraries.lombok)
+    annotationProcessor(Libraries.pf4j)
+
+    compileOnly("com.openosrs:runelite-api:$rlVersion")
+    compileOnly("com.openosrs:runelite-client:$rlVersion")
+
+    compileOnly("com.openosrs.externals:xptracker:0.0.+")
+
+    compileOnly(Libraries.annotations)
+    compileOnly(Libraries.guice)
+    compileOnly(Libraries.lombok)
+    compileOnly(Libraries.pf4j)
+}
+
+tasks {
+    jar {
+        manifest {
+            attributes(mapOf(
+                    "Plugin-Version" to project.version,
+                    "Plugin-Id" to nameToId(project.extra["PluginName"] as String),
+                    "Plugin-Provider" to project.extra["PluginProvider"],
+                    "Plugin-Dependencies" to nameToId("xptracker"),
+                    "Plugin-Description" to project.extra["PluginDescription"],
+                    "Plugin-License" to project.extra["PluginLicense"]
+            ))
+        }
+    }
+}

--- a/sorceressgarden/sorceressgarden.gradle.kts
+++ b/sorceressgarden/sorceressgarden.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     compileOnly(Libraries.guice)
     compileOnly(Libraries.lombok)
     compileOnly(Libraries.pf4j)
+    compileOnly(Libraries.apacheCommonsText)
 }
 
 tasks {

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenConfig.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenConfig.java
@@ -1,0 +1,91 @@
+package net.runelite.client.plugins.sorceressgarden;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("SorceressGarden")
+
+public interface SorceressGardenConfig extends Config
+{
+	@ConfigItem(
+		keyName = "showGardenStats",
+		name = "Show Garden Stats",
+		description = "Shows the player's garden stats",
+		position = 0
+	)
+	default boolean showGardenStats()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showSqirksStats",
+		name = "Show Sqi'rks Stats",
+		description = "Show the amount of sqi'rks the player has collected",
+		position = 1
+	)
+	default boolean showSqirksStats()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showSafeTiles",
+		name = "Show Safe Tiles",
+		description = "Show the safe tiles within each garden",
+		position = 2
+	)
+	default boolean showSafeTiles()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "highlightElementals",
+		name = "Highlight Elementals",
+		description = "Highlights the garden elementals",
+		position = 3
+	)
+	default boolean highlightElementals()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showOneClickSync",
+		name = "Show One-Click Syncing",
+		description = "Show one-clicking indicators for the gardens",
+		position = 4
+	)
+	default boolean showOneClickSync()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showWinterOneClick",
+		name = "Show Winter One-Click",
+		description = "Show the elemental sync for Winter Garden one-clicking",
+		hidden = true,
+		unhide = "showOneClickSync",
+		position = 5
+	)
+	default boolean showWinterOneClick()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showSummerOneClick",
+		name = "Show Summer One-Click",
+		description = "Show the elemental sync for Summer Garden one-clicking",
+		hidden = true,
+		unhide = "showOneClickSync",
+		position = 6
+	)
+	default boolean showSummerOneClick()
+	{
+		return false;
+	}
+}

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenConfig.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenConfig.java
@@ -88,4 +88,15 @@ public interface SorceressGardenConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		name = "Enable mirror mode",
+		description = "Toggle mirror mode compatibility.",
+		position = 7,
+		keyName = "mirrorMode"
+	)
+	default boolean mirrorMode()
+	{
+		return false;
+	}
 }

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenOverlay.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenOverlay.java
@@ -1,0 +1,377 @@
+package net.runelite.client.plugins.sorceressgarden;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.util.Set;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY;
+import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY_CONFIG;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
+import net.runelite.api.Perspective;
+import net.runelite.api.Player;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.queries.NPCQuery;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+@Slf4j
+public class SorceressGardenOverlay extends OverlayPanel
+{
+	static final String GARDEN_RESET = "Reset";
+	final SorceressGardenPlugin plugin;
+	private final SorceressGardenConfig config;
+	private final Client client;
+
+	@Inject
+	public SorceressGardenOverlay(final SorceressGardenPlugin plugin, final SorceressGardenConfig config, Client client)
+	{
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.plugin = plugin;
+		this.config = config;
+		this.client = client;
+
+		// I am unsure what the below two lines do!
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Sorceress Garden Overlay"));
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, GARDEN_RESET, "Sorceress Garden overlay"));
+
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+		setPriority(OverlayPriority.HIGH);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!plugin.isInGarden())
+		{
+			return null;
+		}
+
+		if (config.showSafeTiles())
+		{
+			renderSafeTiles(graphics);
+		}
+
+		if (config.highlightElementals())
+		{
+			renderElementals(graphics);
+		}
+
+		if (config.showOneClickSync())
+		{
+			if (config.showWinterOneClick())
+			{
+				renderWinterOneClick(graphics);
+			}
+
+			if (config.showSummerOneClick())
+			{
+				renderSummerOneClick(graphics);
+			}
+		}
+
+		return super.render(graphics);
+	}
+
+	private void renderTile(final Graphics2D graphics, final LocalPoint dest, final Color color)
+	{
+		if (dest == null)
+		{
+			return;
+		}
+
+		final Polygon poly = Perspective.getCanvasTilePoly(client, dest);
+
+		if (poly == null)
+		{
+			return;
+		}
+
+		OverlayUtil.renderPolygon(graphics, poly, color);
+	}
+
+	private void renderText(final Graphics2D graphics, final LocalPoint dest, final String text, final Color color)
+	{
+		if (dest == null)
+		{
+			return;
+		}
+
+		Point textLocation = Perspective.getCanvasTextLocation(client, graphics, dest, text, 0);
+		if (textLocation != null)
+		{
+			OverlayUtil.renderTextLocation(graphics, textLocation, text, color);
+		}
+	}
+
+	private void renderSafeTiles(Graphics2D graphics)
+	{
+		final Set<WorldPoint> SAFE_TILES = Set.of(
+			// Winter Garden
+			new WorldPoint(2900, 5470, 0),
+			new WorldPoint(2900, 5476, 0),
+			new WorldPoint(2892, 5484, 0),
+
+			// Spring Garden
+			new WorldPoint(2923, 5471, 0),
+			new WorldPoint(2923, 5472, 0),
+			new WorldPoint(2923, 5473, 0),
+			new WorldPoint(2923, 5465, 0),
+			new WorldPoint(2923, 5466, 0),
+			new WorldPoint(2923, 5459, 0),
+			new WorldPoint(2924, 5468, 0),
+			new WorldPoint(2926, 5468, 0),
+			new WorldPoint(2926, 5470, 0),
+			new WorldPoint(2927, 5470, 0),
+			new WorldPoint(2928, 5470, 0),
+			new WorldPoint(2930, 5470, 0),
+			new WorldPoint(2933, 5468, 0),
+
+			// Autumn Garden
+			new WorldPoint(2910, 5460, 0),
+			new WorldPoint(2908, 5461, 0),
+			new WorldPoint(2904, 5459, 0),
+			new WorldPoint(2902, 5461, 0),
+			new WorldPoint(2899, 5457, 0),
+			new WorldPoint(2899, 5458, 0),
+			new WorldPoint(2899, 5459, 0),
+			new WorldPoint(2900, 5458, 0),
+			new WorldPoint(2901, 5455, 0),
+			new WorldPoint(2901, 5456, 0),
+			new WorldPoint(2901, 5457, 0),
+			new WorldPoint(2901, 5458, 0),
+			new WorldPoint(2899, 5455, 0),
+			new WorldPoint(2899, 5453, 0),
+			new WorldPoint(2901, 5451, 0),
+			new WorldPoint(2903, 5450, 0),
+			new WorldPoint(2902, 5453, 0),
+			new WorldPoint(2906, 5458, 0),
+			new WorldPoint(2907, 5458, 0),
+			new WorldPoint(2908, 5456, 0),
+			new WorldPoint(2913, 5454, 0),
+
+			// Summer Garden
+			new WorldPoint(2908, 5482, 0),
+			new WorldPoint(2906, 5483, 0),
+			new WorldPoint(2906, 5485, 0),
+			new WorldPoint(2906, 5488, 0),
+			new WorldPoint(2906, 5489, 0),
+			new WorldPoint(2906, 5490, 0),
+			new WorldPoint(2906, 5491, 0),
+			new WorldPoint(2906, 5492, 0),
+			new WorldPoint(2909, 5494, 0),
+			new WorldPoint(2909, 5493, 0),
+			new WorldPoint(2909, 5492, 0),
+			new WorldPoint(2909, 5491, 0),
+			new WorldPoint(2909, 5490, 0),
+			new WorldPoint(2909, 5488, 0),
+			new WorldPoint(2909, 5487, 0),
+			new WorldPoint(2909, 5486, 0),
+			new WorldPoint(2909, 5485, 0),
+			new WorldPoint(2909, 5484, 0),
+			new WorldPoint(2910, 5485, 0),
+			new WorldPoint(2910, 5484, 0),
+			new WorldPoint(2911, 5485, 0),
+			new WorldPoint(2911, 5484, 0),
+			new WorldPoint(2924, 5485, 0),
+			new WorldPoint(2924, 5487, 0),
+			new WorldPoint(2920, 5488, 0)
+		);
+
+		for (WorldPoint safeTile : SAFE_TILES)
+		{
+			if (safeTile.getPlane() != client.getPlane())
+			{
+				return;
+			}
+
+			LocalPoint lp = LocalPoint.fromWorld(client, safeTile);
+			if (lp == null)
+			{
+				return;
+			}
+
+			Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+			if (poly == null)
+			{
+				return;
+			}
+
+			OverlayUtil.renderPolygon(graphics, poly, Color.GREEN);
+		}
+	}
+
+	private void renderElementals(Graphics2D graphics)
+	{
+		for (NPC nearbyNPC : client.getNpcs())
+		{
+			Color color;
+
+			if (nearbyNPC == null)
+			{
+				continue;
+			}
+
+			if (nearbyNPC.getName().contains("Elemental"))
+			{
+				color = Color.ORANGE;
+			}
+			else
+			{
+				continue;
+			}
+
+			LocalPoint lp = nearbyNPC.getLocalLocation();
+			Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+
+			if (poly != null)
+			{
+				OverlayUtil.renderPolygon(graphics, poly, color);
+			}
+		}
+	}
+
+	private void renderWinterOneClick(Graphics2D graphics)
+	{
+		WorldPoint winterCheckTile = new WorldPoint(2899, 5468, 0);
+		WorldPoint winterStartTile = new WorldPoint(2902, 5470, 0);
+		int winterNPCID = NpcID.WINTER_ELEMENTAL;
+		NPC winterNPC = new NPCQuery().idEquals(winterNPCID).result(client).nearestTo(client.getLocalPlayer());
+
+		if (winterNPC == null)
+		{
+			return;
+		}
+
+		// Sync tile
+		final LocalPoint checkTileLocal = LocalPoint.fromWorld(client, winterCheckTile);
+
+		if (checkTileLocal == null)
+		{
+			log.info("Sync tile local is null");
+			return;
+		}
+
+		if (winterNPC.getWorldLocation().equals(winterCheckTile) && winterNPC.getOrientation() == 1024)
+		{
+			renderTile(graphics, checkTileLocal, Color.GREEN);
+			renderText(graphics, checkTileLocal, "Check", Color.GREEN);
+		}
+		else
+		{
+			renderTile(graphics, checkTileLocal, Color.RED);
+			renderText(graphics, checkTileLocal, "Check", Color.RED);
+		}
+
+		// Start Tile
+		final LocalPoint startTileLocal = LocalPoint.fromWorld(client, winterStartTile);
+
+		if (startTileLocal == null)
+		{
+			return;
+		}
+
+		Player localPlayer = client.getLocalPlayer();
+
+		if (localPlayer != null && localPlayer.getWorldLocation().equals(winterStartTile))
+		{
+			renderTile(graphics, startTileLocal, Color.GREEN);
+			renderText(graphics, startTileLocal, "Start", Color.GREEN);
+		}
+		else
+		{
+			renderTile(graphics, startTileLocal, Color.RED);
+			renderText(graphics, startTileLocal, "Start", Color.RED);
+		}
+	}
+
+	private void renderSummerOneClick(Graphics2D graphics)
+	{
+		WorldPoint summerSyncTile = new WorldPoint(2907, 5489, 0);
+		WorldPoint summerCheckTile = new WorldPoint(2907, 5485, 0);
+		WorldPoint summerStartTile = new WorldPoint(2908, 5482, 0);
+		int northSummerNPCID = NpcID.SUMMER_ELEMENTAL_1802;
+		int southSummerNPCID = NpcID.SUMMER_ELEMENTAL;
+
+		NPC northSummerNPC = new NPCQuery().idEquals(northSummerNPCID).result(client).nearestTo(client.getLocalPlayer());
+		NPC southSummerNPC = new NPCQuery().idEquals(southSummerNPCID).result(client).nearestTo(client.getLocalPlayer());
+
+		if (northSummerNPC == null || southSummerNPC == null)
+		{
+			return;
+		}
+
+		// Sync Tile
+		final LocalPoint syncTileLocal = LocalPoint.fromWorld(client, summerSyncTile);
+
+		if (syncTileLocal == null)
+		{
+			return;
+		}
+
+		if (summerSyncTile.distanceTo(northSummerNPC.getWorldLocation()) == summerSyncTile.distanceTo(southSummerNPC.getWorldLocation()))
+		{
+			renderTile(graphics, syncTileLocal, Color.GREEN);
+			renderText(graphics, syncTileLocal, "Sync", Color.GREEN);
+		}
+		else
+		{
+			renderTile(graphics, syncTileLocal, Color.RED);
+			renderText(graphics, syncTileLocal, "Sync", Color.RED);
+		}
+
+		// Start Tile
+		final LocalPoint startTileLocal = LocalPoint.fromWorld(client, summerStartTile);
+
+		if (startTileLocal == null)
+		{
+			return;
+		}
+
+		Player localPlayer = client.getLocalPlayer();
+
+		if (localPlayer != null && localPlayer.getWorldLocation().equals(summerStartTile))
+		{
+			renderTile(graphics, startTileLocal, Color.GREEN);
+			renderText(graphics, startTileLocal, "Start", Color.GREEN);
+		}
+		else
+		{
+			renderTile(graphics, startTileLocal, Color.RED);
+			renderText(graphics, startTileLocal, "Start", Color.RED);
+		}
+
+
+		// Check Tile
+		final LocalPoint checkTileLocal = LocalPoint.fromWorld(client, summerCheckTile);
+
+		if (checkTileLocal == null)
+		{
+			return;
+		}
+
+		if (southSummerNPC.getWorldLocation().equals(summerCheckTile) && southSummerNPC.getOrientation() == 1024)
+		{
+			renderTile(graphics, checkTileLocal, Color.GREEN);
+			renderText(graphics, checkTileLocal, "Check", Color.GREEN);
+		}
+		else
+		{
+			renderTile(graphics, checkTileLocal, Color.RED);
+			renderText(graphics, checkTileLocal, "Check", Color.RED);
+		}
+	}
+}
+

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenOverlay.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenOverlay.java
@@ -34,7 +34,7 @@ public class SorceressGardenOverlay extends OverlayPanel
 	public SorceressGardenOverlay(final SorceressGardenPlugin plugin, final SorceressGardenConfig config, Client client)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.ABOVE_SCENE);
+		determineLayer();
 		setPriority(OverlayPriority.HIGH);
 		this.plugin = plugin;
 		this.config = config;
@@ -73,6 +73,11 @@ public class SorceressGardenOverlay extends OverlayPanel
 		}
 
 		return super.render(graphics);
+	}
+
+	public void determineLayer()
+	{
+		setLayer(config.mirrorMode() ? OverlayLayer.AFTER_MIRROR : OverlayLayer.ABOVE_SCENE);
 	}
 
 	private void renderTile(final Graphics2D graphics, final LocalPoint dest, final Color color)

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenOverlay.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenOverlay.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.util.Objects;
 import java.util.Set;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +45,7 @@ public class SorceressGardenOverlay extends OverlayPanel
 
 		// I am unsure what the below two lines do!
 		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Sorceress Garden Overlay"));
-		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, GARDEN_RESET, "Sorceress Garden overlay"));
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, GARDEN_RESET, "Sorceress Garden Overlay"));
 
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
@@ -224,7 +225,7 @@ public class SorceressGardenOverlay extends OverlayPanel
 				continue;
 			}
 
-			if (nearbyNPC.getName().contains("Elemental"))
+			if (Objects.requireNonNull(nearbyNPC.getName()).contains("Elemental"))
 			{
 				color = Color.ORANGE;
 			}

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenOverlay.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenOverlay.java
@@ -9,8 +9,6 @@ import java.util.Set;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY;
-import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY_CONFIG;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.Perspective;
@@ -20,8 +18,6 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.ui.overlay.OverlayLayer;
-import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
-import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
@@ -30,7 +26,6 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 @Slf4j
 public class SorceressGardenOverlay extends OverlayPanel
 {
-	static final String GARDEN_RESET = "Reset";
 	final SorceressGardenPlugin plugin;
 	private final SorceressGardenConfig config;
 	private final Client client;
@@ -38,18 +33,12 @@ public class SorceressGardenOverlay extends OverlayPanel
 	@Inject
 	public SorceressGardenOverlay(final SorceressGardenPlugin plugin, final SorceressGardenConfig config, Client client)
 	{
-		setPosition(OverlayPosition.TOP_LEFT);
-		this.plugin = plugin;
-		this.config = config;
-		this.client = client;
-
-		// I am unsure what the below two lines do!
-		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Sorceress Garden Overlay"));
-		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, GARDEN_RESET, "Sorceress Garden Overlay"));
-
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		setPriority(OverlayPriority.HIGH);
+		this.plugin = plugin;
+		this.config = config;
+		this.client = client;
 	}
 
 	@Override

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenPlugin.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenPlugin.java
@@ -10,10 +10,8 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.XpDropEvent;
 import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginType;
-import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
 import net.runelite.client.ui.overlay.OverlayManager;
 import org.apache.commons.lang3.ArrayUtils;
 import org.pf4j.Extension;
@@ -26,7 +24,7 @@ import org.pf4j.Extension;
 	tags = {"sorceress", "garden", "sqirk", "sq'irk", "thieving", "farming"},
 	type = PluginType.MINIGAME
 )
-@PluginDependency(XpTrackerPlugin.class)
+
 public class SorceressGardenPlugin extends Plugin
 {
 	private static final int GARDEN_REGION = 11605;
@@ -93,13 +91,13 @@ public class SorceressGardenPlugin extends Plugin
 	@Subscribe
 	private void onXpDropEvent(XpDropEvent event)
 	{
-		if (!isInGarden() || !config.showSqirksStats())
+		if (!config.showSqirksStats())
 		{
 			return;
 		}
 
 		// Switch based off of XP gained, this is how we determine which Sqi'rk was picked
-		if (event.getSkill() == Skill.FARMING)
+		if (event.getSkill() == Skill.FARMING && isInGarden())
 		{
 			switch (event.getExp())
 			{

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenPlugin.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenPlugin.java
@@ -1,0 +1,118 @@
+package net.runelite.client.plugins.sorceressgarden;
+
+import com.google.inject.Provides;
+import java.util.Arrays;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.ItemID;
+import net.runelite.api.Skill;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.XpDropEvent;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDependency;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.PluginType;
+import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
+import net.runelite.client.ui.overlay.OverlayManager;
+import org.pf4j.Extension;
+
+@Extension
+@PluginDescriptor(
+	name = "Sorceress's Garden",
+	enabledByDefault = false,
+	description = "Provides various utilities for the Sorceress's Garden minigame",
+	tags = {"sorceress", "garden", "sqirk", "sq'irk", "thieving", "farming"},
+	type = PluginType.MINIGAME
+)
+@PluginDependency(XpTrackerPlugin.class)
+@Slf4j
+public class SorceressGardenPlugin extends Plugin
+{
+	private static final int GARDEN_REGION = 11605;
+
+	@Inject
+	private SorceressGardenConfig config;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private SorceressGardenOverlay sorceressGardenOverlay;
+
+	@Inject
+	private SorceressSqirkOverlay sorceressSqirkOverlay;
+
+	@Inject
+	private SorceressSqirks sorceressSqirks;
+
+	@Inject
+	private Client client;
+
+	@Provides
+	SorceressGardenConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(SorceressGardenConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		// runs on plugin startup
+		overlayManager.add(sorceressGardenOverlay);
+		overlayManager.add(sorceressSqirkOverlay);
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		// runs on plugin shutdown
+		overlayManager.remove(sorceressGardenOverlay);
+		overlayManager.remove(sorceressSqirkOverlay);
+	}
+
+	@Subscribe
+	private void onXpDropEvent(XpDropEvent event)
+	{
+		if (!isInGarden() || !config.showSqirksStats())
+		{
+			return;
+		}
+
+		// Switch based off of XP gained, this is how we determine which Sqi'rk was picked
+		if (event.getSkill() == Skill.FARMING)
+		{
+			switch (event.getExp())
+			{
+				case 30:
+					sorceressSqirks.incrementSqirks(ItemID.WINTER_SQIRK);
+					break;
+				case 40:
+					sorceressSqirks.incrementSqirks(ItemID.SPRING_SQIRK);
+					break;
+				case 50:
+					sorceressSqirks.incrementSqirks(ItemID.AUTUMN_SQIRK);
+					break;
+				case 60:
+					sorceressSqirks.incrementSqirks(ItemID.SUMMER_SQIRK);
+					break;
+			}
+		}
+	}
+
+	boolean isInGarden()
+	{
+		GameState gameState = client.getGameState();
+		if (gameState != GameState.LOGGED_IN
+			&& gameState != GameState.LOADING)
+		{
+			return false;
+		}
+
+		int[] currentMapRegions = client.getMapRegions();
+
+		return Arrays.stream(currentMapRegions).anyMatch(region -> region == GARDEN_REGION);
+	}
+}

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenPlugin.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenPlugin.java
@@ -46,7 +46,7 @@ public class SorceressGardenPlugin extends Plugin
 	private SorceressSqirkOverlay sorceressSqirkOverlay;
 
 	@Inject
-	private SorceressSqirks sorceressSqirks;
+	private SorceressSession sorceressSession;
 
 	@Inject
 	private Client client;
@@ -87,16 +87,17 @@ public class SorceressGardenPlugin extends Plugin
 			switch (event.getExp())
 			{
 				case 30:
-					sorceressSqirks.incrementSqirks(ItemID.WINTER_SQIRK);
+					log.info("Winter sqirk picked");
+					sorceressSession.incrementSqirks(ItemID.WINTER_SQIRK);
 					break;
 				case 40:
-					sorceressSqirks.incrementSqirks(ItemID.SPRING_SQIRK);
+					sorceressSession.incrementSqirks(ItemID.SPRING_SQIRK);
 					break;
 				case 50:
-					sorceressSqirks.incrementSqirks(ItemID.AUTUMN_SQIRK);
+					sorceressSession.incrementSqirks(ItemID.AUTUMN_SQIRK);
 					break;
 				case 60:
-					sorceressSqirks.incrementSqirks(ItemID.SUMMER_SQIRK);
+					sorceressSession.incrementSqirks(ItemID.SUMMER_SQIRK);
 					break;
 			}
 		}

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenPlugin.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressGardenPlugin.java
@@ -21,7 +21,7 @@ import org.pf4j.Extension;
 
 @Extension
 @PluginDescriptor(
-	name = "Sorceress's Garden",
+	name = "Sorceress' Garden",
 	enabledByDefault = false,
 	description = "Provides various utilities for the Sorceress's Garden minigame",
 	tags = {"sorceress", "garden", "sqirk", "sq'irk", "thieving", "farming"},
@@ -87,7 +87,6 @@ public class SorceressGardenPlugin extends Plugin
 			switch (event.getExp())
 			{
 				case 30:
-					log.info("Winter sqirk picked");
 					sorceressSession.incrementSqirks(ItemID.WINTER_SQIRK);
 					break;
 				case 40:

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSession.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSession.java
@@ -1,12 +1,14 @@
 package net.runelite.client.plugins.sorceressgarden;
 
+import javax.inject.Singleton;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
 
 @Slf4j
-public class SorceressSqirks
+@Singleton
+public class SorceressSession
 {
 	@Getter(AccessLevel.PACKAGE)
 	private int winterSqirk;
@@ -26,6 +28,7 @@ public class SorceressSqirks
 		{
 			case ItemID.WINTER_SQIRK:
 				winterSqirk++;
+				log.info("Winter sqirk is now " + Integer.toString(winterSqirk));
 				break;
 			case ItemID.SPRING_SQIRK:
 				springSqirk++;

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSession.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSession.java
@@ -28,7 +28,6 @@ public class SorceressSession
 		{
 			case ItemID.WINTER_SQIRK:
 				winterSqirk++;
-				log.info("Winter sqirk is now " + Integer.toString(winterSqirk));
 				break;
 			case ItemID.SPRING_SQIRK:
 				springSqirk++;

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirkOverlay.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirkOverlay.java
@@ -1,0 +1,114 @@
+package net.runelite.client.plugins.sorceressgarden;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.xptracker.XpTrackerService;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.ui.overlay.components.table.TableAlignment;
+import net.runelite.client.ui.overlay.components.table.TableComponent;
+
+@Slf4j
+public class SorceressSqirkOverlay extends OverlayPanel
+{
+	final SorceressGardenPlugin plugin;
+	private final SorceressGardenConfig config;
+	private final SorceressSqirks sorceressSqirks;
+
+	@Inject
+	XpTrackerService xpTrackerService;
+
+	@Inject
+	public SorceressSqirkOverlay(final SorceressGardenPlugin plugin, final Client client, final SorceressGardenConfig config, SorceressSqirks sorceressSqirks)
+	{
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.plugin = plugin;
+		this.config = config;
+		this.sorceressSqirks = sorceressSqirks;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!plugin.isInGarden())
+		{
+			return null;
+		}
+
+		if (config.showGardenStats())
+		{
+			renderGardenStats(graphics);
+		}
+
+		if (config.showSqirksStats())
+		{
+			renderSqirksStats(graphics);
+		}
+
+		return super.render(graphics);
+	}
+
+	private void renderGardenStats(Graphics2D graphics)
+	{
+		TableComponent tableComponent = new TableComponent();
+		tableComponent.setColumnAlignments(TableAlignment.LEFT, TableAlignment.RIGHT);
+
+		int farmingActions = xpTrackerService.getActions(Skill.FARMING);
+		if (farmingActions > 0)
+		{
+			panelComponent.getChildren().add(TitleComponent.builder().text("Sorceress' Garden").build());
+			tableComponent.addRow("Sq'irks Picked: ", Integer.toString(xpTrackerService.getActions(Skill.FARMING)));
+			tableComponent.addRow("Sq'irks/Hr: ", Integer.toString(xpTrackerService.getActionsHr(Skill.FARMING)));
+		}
+
+		panelComponent.getChildren().add(tableComponent);
+	}
+
+	private void renderSqirksStats(Graphics2D graphics)
+	{
+		SorceressSqirks sqirks = sorceressSqirks;
+
+		int winterSqirks = sqirks.getWinterSqirk();
+		int springSqirks = sqirks.getSpringSqirk();
+		int autumnSqirks = sqirks.getAutumnSqirk();
+		int summerSqirks = sqirks.getSummerSqirk();
+
+		if (winterSqirks == 0 && springSqirks == 0 && autumnSqirks == 0 && summerSqirks == 0)
+		{
+			return;
+		}
+
+		TableComponent tableComponent = new TableComponent();
+		tableComponent.setColumnAlignments(TableAlignment.LEFT, TableAlignment.RIGHT);
+		panelComponent.getChildren().add(TitleComponent.builder().text("Sq'irks").build());
+
+		if (winterSqirks > 0)
+		{
+			int xpFromWinter = winterSqirks * 70;
+			tableComponent.addRow("Winter Sq'irks: ", Integer.toString(winterSqirks) + " (" + Integer.toString(xpFromWinter) + " XP)");
+		}
+		if (springSqirks > 0)
+		{
+			double xpFromSpring = springSqirks * 337.5;
+			tableComponent.addRow("Spring Sq'irks: ", Integer.toString(springSqirks) + " (" + Double.toString(xpFromSpring) + " XP)");
+		}
+		if (autumnSqirks > 0)
+		{
+			double xpFromAutumn = autumnSqirks * 783.3;
+			tableComponent.addRow("Autumn Sq'irks: ", Integer.toString(autumnSqirks) + " (" + Double.toString(xpFromAutumn) + " XP)");
+		}
+		if (summerSqirks > 0)
+		{
+			int xpFromSummer = summerSqirks * 1500;
+			tableComponent.addRow("Summer Sq'irks: ", Integer.toString(summerSqirks) + " (" + Integer.toString(xpFromSummer) + " XP)");
+		}
+
+		panelComponent.getChildren().add(tableComponent);
+	}
+
+}

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirkOverlay.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirkOverlay.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.xptracker.XpTrackerService;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TitleComponent;
@@ -30,6 +31,7 @@ public class SorceressSqirkOverlay extends OverlayPanel
 		this.plugin = plugin;
 		this.config = config;
 		this.sorceressSession = sorceressSession;
+		determineLayer();
 	}
 
 	@Override
@@ -51,6 +53,11 @@ public class SorceressSqirkOverlay extends OverlayPanel
 		}
 
 		return super.render(graphics);
+	}
+
+	public void determineLayer()
+	{
+		setLayer(config.mirrorMode() ? OverlayLayer.AFTER_MIRROR : OverlayLayer.ABOVE_SCENE);
 	}
 
 	private void renderGardenStats(Graphics2D graphics)

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirkOverlay.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirkOverlay.java
@@ -4,9 +4,10 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
+import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.xptracker.XpTrackerService;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TitleComponent;
@@ -16,20 +17,22 @@ import net.runelite.client.ui.overlay.components.table.TableComponent;
 @Slf4j
 public class SorceressSqirkOverlay extends OverlayPanel
 {
+	static final String SQIRK_RESET = "Reset";
 	final SorceressGardenPlugin plugin;
 	private final SorceressGardenConfig config;
-	private final SorceressSqirks sorceressSqirks;
-
+	private final SorceressSession sorceressSession;
 	@Inject
 	XpTrackerService xpTrackerService;
 
 	@Inject
-	public SorceressSqirkOverlay(final SorceressGardenPlugin plugin, final Client client, final SorceressGardenConfig config, SorceressSqirks sorceressSqirks)
+	public SorceressSqirkOverlay(final SorceressGardenPlugin plugin, final SorceressGardenConfig config, final SorceressSession sorceressSession)
 	{
+		super(plugin);
 		setPosition(OverlayPosition.TOP_LEFT);
 		this.plugin = plugin;
 		this.config = config;
-		this.sorceressSqirks = sorceressSqirks;
+		this.sorceressSession = sorceressSession;
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, SQIRK_RESET, "Sorceress Sqirks Overlay"));
 	}
 
 	@Override
@@ -71,12 +74,12 @@ public class SorceressSqirkOverlay extends OverlayPanel
 
 	private void renderSqirksStats(Graphics2D graphics)
 	{
-		SorceressSqirks sqirks = sorceressSqirks;
+		SorceressSession session = sorceressSession;
 
-		int winterSqirks = sqirks.getWinterSqirk();
-		int springSqirks = sqirks.getSpringSqirk();
-		int autumnSqirks = sqirks.getAutumnSqirk();
-		int summerSqirks = sqirks.getSummerSqirk();
+		int winterSqirks = session.getWinterSqirk();
+		int springSqirks = session.getSpringSqirk();
+		int autumnSqirks = session.getAutumnSqirk();
+		int summerSqirks = session.getSummerSqirk();
 
 		if (winterSqirks == 0 && springSqirks == 0 && autumnSqirks == 0 && summerSqirks == 0)
 		{
@@ -90,22 +93,22 @@ public class SorceressSqirkOverlay extends OverlayPanel
 		if (winterSqirks > 0)
 		{
 			int xpFromWinter = winterSqirks * 70;
-			tableComponent.addRow("Winter Sq'irks: ", Integer.toString(winterSqirks) + " (" + Integer.toString(xpFromWinter) + " XP)");
+			tableComponent.addRow("Winter Sq'irks: ", winterSqirks + " (" + xpFromWinter + " XP)");
 		}
 		if (springSqirks > 0)
 		{
 			double xpFromSpring = springSqirks * 337.5;
-			tableComponent.addRow("Spring Sq'irks: ", Integer.toString(springSqirks) + " (" + Double.toString(xpFromSpring) + " XP)");
+			tableComponent.addRow("Spring Sq'irks: ", springSqirks + " (" + xpFromSpring + " XP)");
 		}
 		if (autumnSqirks > 0)
 		{
 			double xpFromAutumn = autumnSqirks * 783.3;
-			tableComponent.addRow("Autumn Sq'irks: ", Integer.toString(autumnSqirks) + " (" + Double.toString(xpFromAutumn) + " XP)");
+			tableComponent.addRow("Autumn Sq'irks: ", autumnSqirks + " (" + xpFromAutumn + " XP)");
 		}
 		if (summerSqirks > 0)
 		{
 			int xpFromSummer = summerSqirks * 1500;
-			tableComponent.addRow("Summer Sq'irks: ", Integer.toString(summerSqirks) + " (" + Integer.toString(xpFromSummer) + " XP)");
+			tableComponent.addRow("Summer Sq'irks: ", summerSqirks + " (" + xpFromSummer + " XP)");
 		}
 
 		panelComponent.getChildren().add(tableComponent);

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirkOverlay.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirkOverlay.java
@@ -4,10 +4,8 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.xptracker.XpTrackerService;
-import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TitleComponent;
@@ -17,10 +15,10 @@ import net.runelite.client.ui.overlay.components.table.TableComponent;
 @Slf4j
 public class SorceressSqirkOverlay extends OverlayPanel
 {
-	static final String SQIRK_RESET = "Reset";
 	final SorceressGardenPlugin plugin;
 	private final SorceressGardenConfig config;
 	private final SorceressSession sorceressSession;
+
 	@Inject
 	XpTrackerService xpTrackerService;
 
@@ -32,7 +30,6 @@ public class SorceressSqirkOverlay extends OverlayPanel
 		this.plugin = plugin;
 		this.config = config;
 		this.sorceressSession = sorceressSession;
-		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, SQIRK_RESET, "Sorceress Sqirks Overlay"));
 	}
 
 	@Override

--- a/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirks.java
+++ b/sorceressgarden/src/main/java/net/runelite/client/plugins/sorceressgarden/SorceressSqirks.java
@@ -1,0 +1,43 @@
+package net.runelite.client.plugins.sorceressgarden;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ItemID;
+
+@Slf4j
+public class SorceressSqirks
+{
+	@Getter(AccessLevel.PACKAGE)
+	private int winterSqirk;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int springSqirk;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int autumnSqirk;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int summerSqirk;
+
+	void incrementSqirks(int sqirkID)
+	{
+		switch (sqirkID)
+		{
+			case ItemID.WINTER_SQIRK:
+				winterSqirk++;
+				break;
+			case ItemID.SPRING_SQIRK:
+				springSqirk++;
+				break;
+			case ItemID.AUTUMN_SQIRK:
+				autumnSqirk++;
+				break;
+			case ItemID.SUMMER_SQIRK:
+				summerSqirk++;
+				break;
+			default:
+				log.debug("Invalid sqirk specified. The sqirk count will not be updated.");
+		}
+	}
+}


### PR DESCRIPTION
This plugin provides various utilities for the Sorceress' Garden minigame.

**Features:**
- Show how many sqi'rks the player has picked, and their rate of picking per hour
- Show which sqi'rks the player has picked
- Show the safespot tiles to the sqi'rk trees within each garden
- Highlight the elementals in each garden
- Show "one-clicking" indicators:
    - For the winter garden, this provides the user with an indicator for where to stand and when to click on the sq'irk tree
    - For the summer garden, this provides the user with an indicator for where to stand, an indicator for when the bottom-most elementals are "in sync", and an indicator for when to click on the sq'irk tree

**Example of the Summer Garden one-click indicators:**
![](https://i.imgur.com/r5HJUnZ.gif)

**Dependencies:**
- XPTracker

**Notes:**
There are a few things that I think could be modified/updated to be more in-line with other plugins.
- Lines 111 - 181 in `SorceressGardenOverlay.java`. These lines provide the set of all safespot tiles for the gardens. This may need to be done in a better way, or removed altogether.
- Lines 85 - 103 in `SorceressGardenPlugin.java`. The logic for determining which sqi'rk the player has picked is determined by exact XP. This can be calculated incorrectly if the user gets farming XP by some other means and the amount of XP matches one of the cases in this switch statement.
- Lines 90 - 109 in `SorceressSqirkOverlay.java`. The calculations for amount of XP gained are hard-coded. This may need to be refactored to use a constant instead.

**Possible To-Dos:**
- Add logic to support _actual_ sessions (such as having the stats reset after X amount of minutes, and allowing the user to reset stats manually
- Update the summer garden one-click check to be more robust/reliable
- Add stats that show how many glasses of juice the user can make given the amount of sqi'rks they've collected
- Highlight the gates to each garden and display an icon for which kind of sqi'rk the garden provides
- Add support for picking the herbs within the gardens, just like how sq'irks are supported

---

Please let me know if there is anything I missed! This is my first plugin, so I apologize in advance for any messy code or any logic that doesn't follow the usual conventions. I look forward to your feedback.