### PR TITLE
playerattacktimer: update AttackTimerMap

### DIFF
--- a/playerattacktimer/playerattacktimer.gradle.kts
+++ b/playerattacktimer/playerattacktimer.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.4"
+version = "0.0.5"
 
 project.extra["PluginName"] = "Player Attack Timer"
 project.extra["PluginDescription"] = "Display the tick delay for your current weapon.<br>Helps with lazy prayer flicking and flinching."

--- a/playerattacktimer/src/main/java/net/runelite/client/plugins/playerattacktimer/AttackTimerMap.java
+++ b/playerattacktimer/src/main/java/net/runelite/client/plugins/playerattacktimer/AttackTimerMap.java
@@ -13,6 +13,29 @@ final class AttackTimerMap
 
 	static
 	{
+		// sorted by animation ID
+		ATTACK_TIMER_MAP.put(386, 4); // arclight stab
+		ATTACK_TIMER_MAP.put(390, 4); // arclight slash
+		ATTACK_TIMER_MAP.put(393, 4);
+		ATTACK_TIMER_MAP.put(395, 6); // Battleaxe slash
+		ATTACK_TIMER_MAP.put(400, 5); // Pickaxe crush
+		ATTACK_TIMER_MAP.put(401, 5); // Pickaxe stab + battleaxe crush (5 tick and 6 tick respectively)
+		ATTACK_TIMER_MAP.put(426, 5); // tbow rapid, 6 tick accurate/long range
+		ATTACK_TIMER_MAP.put(428, 7); // Halberd Stab
+		ATTACK_TIMER_MAP.put(440, 7); // Halberd Slash
+		ATTACK_TIMER_MAP.put(1167, 4);
+		ATTACK_TIMER_MAP.put(1203, 7); // Halberd special
+		ATTACK_TIMER_MAP.put(1378, 6);
 		ATTACK_TIMER_MAP.put(1658, 4); // Abyssal whip
+		ATTACK_TIMER_MAP.put(1711, 4);
+		ATTACK_TIMER_MAP.put(1978, 5); // Ice Blitz
+		ATTACK_TIMER_MAP.put(1979, 5); // Ice Barrage
+		ATTACK_TIMER_MAP.put(5061, 2); // Blowpipe - note we assume 2 ticks but is 3 ticks in PVP and on long range/accurate
+		ATTACK_TIMER_MAP.put(7514, 4);
+		ATTACK_TIMER_MAP.put(7554, 2); // Darts
+		ATTACK_TIMER_MAP.put(8056, 5);
+		ATTACK_TIMER_MAP.put(8145, 4);
+		ATTACK_TIMER_MAP.put(8288, 4);
+		ATTACK_TIMER_MAP.put(76181, 4);
 	}
 }


### PR DESCRIPTION
Added a few more animation IDs

Unfortunately OSRS shares several animation IDs across different weapons
For example Tbow animation ID is 426 and is either 5 tick or 6 tick based on attack style.

Would need additional logic to account for currently equipped weapon