### PR TITLE
socketdeathindicators: fix for hiding unwanted npcs

### DIFF
--- a/socketdeathindicator/socketdeathindicator.gradle.kts
+++ b/socketdeathindicator/socketdeathindicator.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.3"
+version = "0.0.4"
 
 project.extra["PluginName"] = "Socket Death Indicator"
 project.extra["PluginDescription"] = "Socket extension for extending removing dead nylocas during Theatre"

--- a/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorPlugin.java
+++ b/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorPlugin.java
@@ -98,6 +98,8 @@ public class SocketDeathIndicatorPlugin extends Plugin
 	@Getter
 	private NyloQ maidenNPC;
 
+	private ArrayList<Integer> hiddenIndices;
+
 	@Provides
 	SocketDeathIndicatorsConfig getConfig(ConfigManager configManager)
 	{
@@ -109,6 +111,7 @@ public class SocketDeathIndicatorPlugin extends Plugin
 	{
 		deadNylos = new ArrayList<>();
 		nylos = new ArrayList<>();
+		hiddenIndices = new ArrayList<>();
 		overlayManager.add(overlay);
 	}
 
@@ -117,6 +120,7 @@ public class SocketDeathIndicatorPlugin extends Plugin
 	{
 		deadNylos = null;
 		nylos = null;
+		hiddenIndices = null;
 		overlayManager.remove(overlay);
 	}
 
@@ -372,19 +376,6 @@ public class SocketDeathIndicatorPlugin extends Plugin
 		}
 	}
 
-	@Subscribe
-	public void onMenuEntryAdded(MenuEntryAdded entry)
-	{
-		if (config.hideNyloMenuEntries())
-		{
-			getDeadNylos()
-					.stream()
-					.filter(deadNylo -> entry.getIdentifier() == deadNylo.getIndex())
-					.forEach(deadNylo -> client.setMenuOptionCount(client.getMenuOptionCount() - 1));
-		}
-
-	}
-
 	private void setHiddenNpc(NPC npc, boolean hidden)
 	{
 
@@ -392,6 +383,7 @@ public class SocketDeathIndicatorPlugin extends Plugin
 		if (hidden)
 		{
 			newHiddenNpcIndicesList.add(npc.getIndex());
+			hiddenIndices.add(npc.getIndex());
 		}
 		else
 		{
@@ -400,6 +392,7 @@ public class SocketDeathIndicatorPlugin extends Plugin
 				newHiddenNpcIndicesList.remove((Integer) npc.getIndex());
 			}
 		}
+		log.info(newHiddenNpcIndicesList.toString());
 		client.setHiddenNpcIndices(newHiddenNpcIndicesList);
 
 	}
@@ -581,6 +574,13 @@ public class SocketDeathIndicatorPlugin extends Plugin
 		else
 		{
 			inNylo = false;
+			if (!hiddenIndices.isEmpty())
+			{
+				List<Integer> newHiddenNpcIndicesList = client.getHiddenNpcIndices();
+				newHiddenNpcIndicesList.removeAll(hiddenIndices);
+				client.setHiddenNpcIndices(newHiddenNpcIndicesList);
+				hiddenIndices.clear();
+			}
 		}
 	}
 

--- a/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorPlugin.java
+++ b/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorPlugin.java
@@ -45,7 +45,6 @@ import net.runelite.api.NPC;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
-import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.ScriptPreFired;

--- a/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorsConfig.java
+++ b/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorsConfig.java
@@ -21,17 +21,6 @@ public interface SocketDeathIndicatorsConfig extends Config
 
 	@ConfigItem(
 			position = 1,
-			keyName = "showOutline",
-			name = "Show outline",
-			description = "Shows outline when killed"
-	)
-	default boolean showOutline()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			position = 2,
 			keyName = "hideNylo",
 			name = "Hide Nylo",
 			description = "Hides nylo when killed"
@@ -42,18 +31,7 @@ public interface SocketDeathIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 3,
-			keyName = "hideNyloMenuEntries",
-			name = "Hide Nylo Menu Entries",
-			description = "Hides attack option on Nylos when they die"
-	)
-	default boolean hideNyloMenuEntries()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			position = 4,
+			position = 2,
 			keyName = "maidenMarkers",
 			name = "Maiden Markers",
 			description = "Maiden Outline"

--- a/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorsOverlay.java
+++ b/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorsOverlay.java
@@ -32,12 +32,6 @@ public class SocketDeathIndicatorsOverlay extends Overlay
 
 	public Dimension render(Graphics2D graphics)
 	{
-		if (config.showOutline())
-		{
-			plugin.getDeadNylos().stream()
-					.map(Actor::getConvexHull)
-					.forEach(objectClickbox -> OverlayUtil.renderPolygon(graphics, objectClickbox, Color.RED));
-		}
 
 		if (plugin.getMaidenNPC() != null && config.maidenMarkers())
 		{

--- a/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorsOverlay.java
+++ b/socketdeathindicator/src/main/java/net/runelite/client/plugins/socketdeathindicator/SocketDeathIndicatorsOverlay.java
@@ -1,6 +1,5 @@
 package net.runelite.client.plugins.socketdeathindicator;
 
-import net.runelite.api.Actor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;


### PR DESCRIPTION
- remove hiding of menu entries since it was a bootleg fix in the first place
- remove highlighting dead nylos 
- add the cleanup for the NPCs indices in the client array list, this was causing issues because when I wasn't cleaning up the array, if another NPC spawned with the same index as a nylo that was killed in nylo it would not render on the screen. 