### PR TITLE
alchemicalhydra: fix reseting

### DIFF
--- a/alchemicalhydra/alchemicalhydra.gradle.kts
+++ b/alchemicalhydra/alchemicalhydra.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.0"
+version = "5.0.1"
 
 project.extra["PluginName"] = "Alchemical Hydra"
 project.extra["PluginDescription"] = "A plugin for the Alchemical Hydra boss."

--- a/alchemicalhydra/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraPlugin.java
+++ b/alchemicalhydra/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraPlugin.java
@@ -143,12 +143,14 @@ public class AlchemicalHydraPlugin extends Plugin
 	@Override
 	protected void shutDown()
 	{
-		atHydra = false;
-
 		eventBus.unregister(this);
+		reset();
+	}
 
+	private void reset()
+	{
+		atHydra = false;
 		removeOverlays();
-
 		hydra = null;
 		poisonProjectiles.clear();
 		lastAttackTick = -1;
@@ -173,7 +175,7 @@ public class AlchemicalHydraPlugin extends Plugin
 				{
 					if (atHydra)
 					{
-						shutDown();
+						reset();
 					}
 				}
 				break;
@@ -181,7 +183,7 @@ public class AlchemicalHydraPlugin extends Plugin
 			case LOGIN_SCREEN:
 				if (atHydra)
 				{
-					shutDown();
+					reset();
 				}
 			default:
 				break;

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,7 +24,7 @@
  */
 
 object ProjectVersions {
-    const val rlVersion = "4.2.1"
+    const val rlVersion = "4.3.0"
     const val apiVersion = "^1.0.0"
     const val kotlinVersion = "1.3.72"
 }


### PR DESCRIPTION
eventBus.unregister(this); unsubscribes the gamestatechanged so the plugin never resets/re-adds the overlays

moved the reseting to a reset function and call that instead of shutdown()