### PR TITLE
Nightmare: actually fix

### DIFF
--- a/nightmare/nightmare.gradle.kts
+++ b/nightmare/nightmare.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.3"
+version = "5.0.4"
 
 project.extra["PluginName"] = "Nightmare of Ashihama"
 project.extra["PluginDescription"] = "Shows what to pray and what to do at Nightmare of Ashihama"

--- a/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmarePlugin.java
+++ b/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmarePlugin.java
@@ -216,6 +216,11 @@ public class NightmarePlugin extends Plugin
 	@Subscribe
 	public void onAnimationChanged(AnimationChanged event)
 	{
+		if (!inFight || nm == null)
+		{
+			return;
+		}
+
 		Actor actor = event.getActor();
 		if (!(actor instanceof NPC))
 		{
@@ -224,23 +229,8 @@ public class NightmarePlugin extends Plugin
 
 		NPC npc = (NPC) actor;
 		int id = npc.getId();
-		
-		//this will trigger once when the fight begins
-		if (id == 9432)
-		{
-			//reset everything
-			reset();
-			nm = npc;
-			inFight = true;
-		}
-		
-		if (!inFight || nm == null)
-		{
-			return;
-		}
-		
 		int animationId = npc.getAnimation();
-		
+
 		if (animationId == NIGHTMARE_MAGIC_ATTACK)
 		{
 			ticksUntilNextAttack = 7;
@@ -299,6 +289,15 @@ public class NightmarePlugin extends Plugin
 		if (npc == null)
 		{
 			return;
+		}
+
+		//this will trigger once when the fight begins
+		if (npc.getId() == 9432)
+		{
+			//reset everything
+			reset();
+			nm = npc;
+			inFight = true;
 		}
 
 		//if ID changes to 9431 (3rd phase) and is cursed, remove the curse

--- a/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmarePlugin.java
+++ b/nightmare/src/main/java/net/runelite/client/plugins/nightmare/NightmarePlugin.java
@@ -225,9 +225,8 @@ public class NightmarePlugin extends Plugin
 		NPC npc = (NPC) actor;
 		int id = npc.getId();
 		
-		// this will trigger once when the fight begins
-		// 9432 is Nightmare Id when it's first woken up, 9425 is Id on a subsequent kill
-		if (id == 9432 || id == 9425)
+		//this will trigger once when the fight begins
+		if (id == 9432)
 		{
 			//reset everything
 			reset();


### PR DESCRIPTION
#369 did not fix the issue.
9425 ID is used throughout P1, not on subsequent kills, this causes the tick counter to constantly reset during P1

#323 why was this even moved to onAnimationChanged?