### PR TITLE
Xarpus instance timer

### DIFF
--- a/theatre/src/main/java/net/runelite/client/plugins/theatre/TheatrePlugin.java
+++ b/theatre/src/main/java/net/runelite/client/plugins/theatre/TheatrePlugin.java
@@ -164,6 +164,7 @@ public class TheatrePlugin extends Plugin
 	public void onClientTick(ClientTick event)
 	{
 		nylocas.onClientTick(event);
+		xarpus.onClientTick(event);
 	}
 
 	@Subscribe

--- a/theatre/src/main/java/net/runelite/client/plugins/theatre/Xarpus/Xarpus.java
+++ b/theatre/src/main/java/net/runelite/client/plugins/theatre/Xarpus/Xarpus.java
@@ -24,6 +24,7 @@ import net.runelite.api.Point;
 import net.runelite.api.Varbits;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.GroundObjectDespawned;
@@ -256,7 +257,11 @@ public class Xarpus extends Room
 		{
 			instanceTimer = (instanceTimer + 1) % 4;
 		}
+	}
 
+	@Subscribe
+	public void onClientTick(ClientTick event)
+	{
 		if (client.getLocalPlayer() == null)
 		{
 			return;

--- a/theatre/theatre.gradle.kts
+++ b/theatre/theatre.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.1"
+version = "5.0.2"
 
 project.extra["PluginName"] = "Theatre Of Blood"
 project.extra["PluginDescription"] = "All-in-one plugin for Theatre of Blood"


### PR DESCRIPTION
Currently the Xarpus instance timer is incorrect by 1tick (correct tick to enter is 3 instead of 0)

Moving the instance timer trigger from GameTick to ClientTick fixes the issue (now enter on 0 as intended)