### PR TITLE
Socket Sotetseg: Fix chosen

### DIFF
--- a/socketsotetseg/socketsotetseg.gradle.kts
+++ b/socketsotetseg/socketsotetseg.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.1"
+version = "5.0.2"
 
 project.extra["PluginName"] = "Socket Sotetseg"
 project.extra["PluginDescription"] = "Extended plugin handler for Sotetseg in the Theatre of Blood."

--- a/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/SotetsegPlugin.java
+++ b/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/SotetsegPlugin.java
@@ -419,6 +419,13 @@ public class SotetsegPlugin extends Plugin
 		if (this.client.getWidget(28, 1) != null)
 		{
 			this.hideWidget(this.client.getWidget(28, 1), false);
+
+			// Clear widget text to prevent chosen set incorrectly sometimes on maze start
+			Widget[] widgetsOfSotetseg = client.getWidget(28, 1).getChildren();
+			for (Widget widget : widgetsOfSotetseg)
+			{
+				widget.setText("");
+			}
 		}
 
 		showFirstTile = false;


### PR DESCRIPTION
Sometimes the chosen flag is incorrectly set when you are NOT chosen, this occurs AFTER you have previously been chosen.
I believe this is due to the widget text not always being cleared.
This is a bug on RuneLite too (seems completely random when it happens)