### PR TITLE
Spellbook: Correct varbit for getting current spellbook

### DIFF
--- a/spellbook/spellbook.gradle.kts
+++ b/spellbook/spellbook.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.0"
+version = "5.0.1"
 
 project.extra["PluginName"] = "Spellbook"
 project.extra["PluginDescription"] = "Modifications to the spellbook"

--- a/spellbook/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
+++ b/spellbook/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
@@ -306,7 +306,7 @@ public class SpellbookPlugin extends Plugin
 		switch (event.getEventName())
 		{
 			case "startSpellRedraw":
-				final Spellbook pook = Spellbook.getByID(client.getVarbitValue(6718));
+				final Spellbook pook = Spellbook.getByID(client.getVarbitValue(4070));
 
 				if (pook != spellbook)
 				{


### PR DESCRIPTION
Correct varbit to get which spellbook.

This was converted wrong as part of 4.0 updates and changing plugins from using Varbits.SPELLBOOK back to just the varbit id.

