### PR TITLE
mesx: fix right click menu conflicts with builtins

### DIFF
--- a/menuentryswapperextended/menuentryswapperextended.gradle.kts
+++ b/menuentryswapperextended/menuentryswapperextended.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.6"
+version = "5.0.7"
 
 project.extra["PluginName"] = "Menu Entry Swapper Extended"
 project.extra["PluginDescription"] = "Change the default option that is displayed when hovering over objects"

--- a/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/MenuEntrySwapperExtendedPlugin.java
+++ b/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/MenuEntrySwapperExtendedPlugin.java
@@ -248,7 +248,7 @@ public class MenuEntrySwapperExtendedPlugin extends Plugin
 			return;
 		}
 
-		event.setMenuEntries(updateMenuEntries(event.getMenuEntries()));
+		event.setMenuEntries(updateMenuEntries(client.getMenuEntries()));
 		event.setModified();
 	}
 


### PR DESCRIPTION
Fixes conflicts with builtin plugins such as:
* Chat history right click copy to clipboard
* Inventory tags

Race condition fix - new entries were already added before mesx onMenuOpened fired, therefore event entries were already invalid.