### PR TITLE
Add true tile to socket sotetseg

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,7 +24,7 @@
  */
 
 object ProjectVersions {
-    const val rlVersion = "4.9.6"
+    const val rlVersion = "4.10.0"
     const val apiVersion = "^1.0.0"
     const val kotlinVersion = "1.3.72"
 }

--- a/socketsotetseg/socketsotetseg.gradle.kts
+++ b/socketsotetseg/socketsotetseg.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.3"
+version = "5.0.4"
 
 project.extra["PluginName"] = "Socket Sotetseg"
 project.extra["PluginDescription"] = "Extended plugin handler for Sotetseg in the Theatre of Blood."

--- a/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/MazeTrueTileOverlay.java
+++ b/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/MazeTrueTileOverlay.java
@@ -1,0 +1,68 @@
+package net.runelite.client.plugins.socketsotetseg;
+
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.awt.RenderingHints;
+
+public class MazeTrueTileOverlay extends Overlay
+{
+
+	private final Client client;
+	private final SotetsegPlugin plugin;
+	private final SotetsegConfig config;
+
+	@Inject
+	private MazeTrueTileOverlay(Client client, SotetsegPlugin plugin, SotetsegConfig config)
+	{
+		this.client = client;
+		this.plugin = plugin;
+		this.config = config;
+
+		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.HIGHEST);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (config.trueMaze())
+		{
+			if (plugin.isMazeActive())
+			{
+				WorldPoint playerPos = client.getLocalPlayer().getWorldLocation();
+				if (playerPos == null) return null;
+				LocalPoint playerPosLocal = LocalPoint.fromWorld(client, playerPos);
+				if (playerPosLocal == null) return null;
+				renderTile(graphics, playerPosLocal, Color.red);
+			}
+
+		}
+		return null;
+	}
+
+	private void renderTile(Graphics2D graphics, @Nonnull LocalPoint dest, Color color)
+	{
+		Polygon poly = Perspective.getCanvasTilePoly(client, dest);
+		if (poly == null) return;
+		graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		graphics.setColor(color);
+		graphics.setStroke(new BasicStroke(2));
+		graphics.draw(poly);
+		graphics.setColor(new Color(0, 0, 0, 50));
+
+	}
+}

--- a/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/SotetsegConfig.java
+++ b/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/SotetsegConfig.java
@@ -34,10 +34,10 @@ import net.runelite.client.config.ConfigItem;
 public interface SotetsegConfig extends Config
 {
 	@ConfigItem(
-		position = 1,
-		keyName = "getTileColor",
-		name = "Tile Color",
-		description = "The color of the tiles."
+			position = 1,
+			keyName = "getTileColor",
+			name = "Tile Color",
+			description = "The color of the tiles."
 	)
 	default Color getTileColor()
 	{
@@ -45,10 +45,10 @@ public interface SotetsegConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
-		keyName = "getTileTransparency",
-		name = "Tile Transparency",
-		description = "The color transparency of the tiles. Ranges from 0 to 255, inclusive."
+			position = 2,
+			keyName = "getTileTransparency",
+			name = "Tile Transparency",
+			description = "The color transparency of the tiles. Ranges from 0 to 255, inclusive."
 	)
 	default int getTileTransparency()
 	{
@@ -56,10 +56,10 @@ public interface SotetsegConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
-		keyName = "getTileOutline",
-		name = "Tile Outline Color",
-		description = "The color of the outline of the tiles."
+			position = 3,
+			keyName = "getTileOutline",
+			name = "Tile Outline Color",
+			description = "The color of the outline of the tiles."
 	)
 	default Color getTileOutline()
 	{
@@ -67,10 +67,10 @@ public interface SotetsegConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
-		keyName = "getTileOutlineSize",
-		name = "Tile Outline Size",
-		description = "The size of the outline of the tiles."
+			position = 4,
+			keyName = "getTileOutlineSize",
+			name = "Tile Outline Size",
+			description = "The size of the outline of the tiles."
 	)
 	default int getTileOutlineSize()
 	{
@@ -263,5 +263,15 @@ public interface SotetsegConfig extends Config
 	default int chosenTextDuration()
 	{
 		return 500;
+	}
+
+	@ConfigItem(position = 20,
+			keyName = "trueMaze",
+			name = "Maze True Tile",
+			description = "Shows your true tile in the maze"
+	)
+	default boolean trueMaze()
+	{
+		return true;
 	}
 }

--- a/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/SotetsegPlugin.java
+++ b/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/SotetsegPlugin.java
@@ -204,6 +204,7 @@ public class SotetsegPlugin extends Plugin
 	protected void shutDown()
 	{
 		overlayManager.remove(overlay);
+		overlayManager.remove(mazeOverlay);
 	}
 
 	@Subscribe // Boss has entered the scene. Played has entered the room.

--- a/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/SotetsegPlugin.java
+++ b/socketsotetseg/src/main/java/net/runelite/client/plugins/socketsotetseg/SotetsegPlugin.java
@@ -110,6 +110,9 @@ public class SotetsegPlugin extends Plugin
 	@Inject
 	private SotetsegOverlay overlay;
 
+	@Inject
+	private MazeTrueTileOverlay mazeOverlay;
+
 	// This boolean states whether or not the room is currently active.
 	@Getter(AccessLevel.PUBLIC)
 	private boolean sotetsegActive;
@@ -194,6 +197,7 @@ public class SotetsegPlugin extends Plugin
 		flashFlag = true;
 
 		overlayManager.add(overlay);
+		overlayManager.add(mazeOverlay);
 	}
 
 	@Override


### PR DESCRIPTION
This adds a true tile overlay to sotetseg. The maze overlay renders over the true tile from tile indicators, and you can't turn the border off. This was based off of https://github.com/c13-c/Socket/blob/012a09c2518846260e9b3770ebe8220520eb7c2d/plugins/src/main/java/net/runelite/client/plugins/socket/plugins/sotetseg/MazeTrueTileOverlay.java