### PR TITLE
MESX: Fix remove and hotkey swaps

### DIFF
--- a/menuentryswapperextended/menuentryswapperextended.gradle.kts
+++ b/menuentryswapperextended/menuentryswapperextended.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.1.8"
+version = "5.1.9"
 
 project.extra["PluginName"] = "Menu Entry Swapper Extended"
 project.extra["PluginDescription"] = "Change the default option that is displayed when hovering over objects"

--- a/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/util/CustomSwaps.java
+++ b/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/util/CustomSwaps.java
@@ -194,14 +194,15 @@ public class CustomSwaps implements KeyListener
 				parseConfigToList(config.customSwapsString(), customSwaps);
 				shiftCustomSwaps.clear();
 				parseConfigToList(config.shiftCustomSwapsString(), shiftCustomSwaps);
+				keyCustomSwaps.clear();
+				parseConfigToList(config.keyCustomSwapsString(), keyCustomSwaps);
 				removeOptions.clear();
 				parseConfigToList(config.removeOptionsString(), removeOptions);
 				bankCustomSwaps.clear();
 				parseConfigToList(config.bankCustomSwapsString(), bankCustomSwaps);
 				shiftBankCustomSwaps.clear();
 				parseConfigToList(config.bankShiftCustomSwapsString(), shiftBankCustomSwaps);
-				parseConfigToList(config.keyCustomSwapsString(), keyCustomSwaps);
-				removeOptions.clear();
+				keyBankCustomSwaps.clear();
 				parseConfigToList(config.bankKeyCustomSwapsString(), keyBankCustomSwaps);
 				hasLoaded = true;
 			}


### PR DESCRIPTION
Remove options and hotkey swaps weren't working on startup due to me being a dumby but I fixed it.