### PR TITLE
mesx: change priority for client tick event

### DIFF
--- a/menuentryswapperextended/menuentryswapperextended.gradle.kts
+++ b/menuentryswapperextended/menuentryswapperextended.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.2.1"
+version = "5.2.2"
 
 project.extra["PluginName"] = "Menu Entry Swapper Extended"
 project.extra["PluginDescription"] = "Change the default option that is displayed when hovering over objects"

--- a/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/MenuEntrySwapperExtendedPlugin.java
+++ b/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/MenuEntrySwapperExtendedPlugin.java
@@ -279,7 +279,7 @@ public class MenuEntrySwapperExtendedPlugin extends Plugin
 		}
 	}
 
-	@Subscribe
+	@Subscribe (priority = -1)
 	public void onClientTick(ClientTick clientTick)
 	{
 		// The menu is not rebuilt when it is open, so don't swap or else it will

--- a/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/util/CustomSwaps.java
+++ b/menuentryswapperextended/src/main/java/net/runelite/client/plugins/menuentryswapperextended/util/CustomSwaps.java
@@ -331,7 +331,7 @@ public class CustomSwaps implements KeyListener
 		return filtered.toArray(new MenuEntry[0]);
 	}
 
-	@Subscribe
+	@Subscribe (priority = -1)
 	public void onClientTick(ClientTick event)
 	{
 		if (client.getGameState() != GameState.LOGGED_IN || client.isMenuOpen()


### PR DESCRIPTION
this makes it so that mesx is able to swap menu entries that get added using the clientTick event. 