### PR TITLE
specorb: mouse off screen fix

### DIFF
--- a/specorb/specorb.gradle.kts
+++ b/specorb/specorb.gradle.kts
@@ -24,7 +24,7 @@ import ProjectVersions.rlVersion
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-version = "5.0.2"
+version = "5.0.3"
 
 project.extra["PluginName"] = "Spec Orb"
 project.extra["PluginDescription"] = "Make the special attack orb work everywhere with all weapons"

--- a/specorb/src/main/java/net/runelite/client/plugins/specorb/SpecOrbPlugin.java
+++ b/specorb/src/main/java/net/runelite/client/plugins/specorb/SpecOrbPlugin.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.specorb;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
+import net.runelite.api.Point;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.widgets.Widget;
@@ -23,6 +24,8 @@ public class SpecOrbPlugin extends Plugin
 	@Inject
 	private Client client;
 
+	private final Point invalidMouseLocation = new Point(-1, -1);
+
 	@Subscribe
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
@@ -31,18 +34,19 @@ public class SpecOrbPlugin extends Plugin
 			client.setMenuOptionCount(client.getMenuOptionCount() - 1);
 		}
 	}
-	
+
 	@Subscribe
 	private void onClientTick(ClientTick event)
 	{
 		Widget specOrb = client.getWidget(WidgetInfo.MINIMAP_SPEC_CLICKBOX);
+		Point mousePosition = client.getMouseCanvasPosition();
 
-		if (specOrb == null)
+		if (specOrb == null || mousePosition.equals(invalidMouseLocation))
 		{
 			return;
 		}
-		
-		if (specOrb.getBounds().contains(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY()))
+
+		if (specOrb.getBounds().contains(mousePosition.getX(), mousePosition.getY()))
 		{
 			client.insertMenuItem("Use <col=00ff00>Special Attack</col>", "", MenuAction.CC_OP.getId(), 1, -1, WidgetInfo.COMBAT_SPECIAL_ATTACK_CLICKBOX.getId(), false);
 		}


### PR DESCRIPTION
Plugin no longer adds a menu option when the mouse leaves the screen and runelite sets mouse and orb locations to `Point(-1, -1)`