### PR TITLE
inferno: melee dig timer & blob death indicator

### DIFF
--- a/inferno/inferno.gradle.kts
+++ b/inferno/inferno.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.4"
+version = "5.0.5"
 
 project.extra["PluginName"] = "Inferno"
 project.extra["PluginDescription"] = "Inferno helper"

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/BlobDeathSpot.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/BlobDeathSpot.java
@@ -1,0 +1,54 @@
+package net.runelite.client.plugins.inferno;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.coords.LocalPoint;
+
+class BlobDeathSpot
+{
+
+	static final int BLOB_DEATH_TICKS = 3;
+	static final int BLOB_DEATH_ANIMATION = 7584;
+	static final int FILL_START_ALPHA = 255;
+
+	@Getter(AccessLevel.PACKAGE)
+	private final LocalPoint location;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private Integer ticksUntilDone;
+
+	@Getter(AccessLevel.PACKAGE)
+	private final long deathTime;
+
+	public BlobDeathSpot(LocalPoint location)
+	{
+		this.location = location;
+		this.ticksUntilDone = BLOB_DEATH_TICKS;
+		this.deathTime = System.currentTimeMillis();
+	}
+
+	void decrementTick()
+	{
+		if (ticksUntilDone > 0)
+		{
+			ticksUntilDone -= 1;
+		}
+	}
+
+	boolean isDone()
+	{
+		return ticksUntilDone == 0;
+	}
+
+	double fillProgress()
+	{
+		return (System.currentTimeMillis() - deathTime) / ((BLOB_DEATH_TICKS - 1) * 600.0);
+	}
+
+	int fillAlpha()
+	{
+		return Math.min(Math.max((int) ((1 - fillProgress()) * FILL_START_ALPHA), 0), 255);
+	}
+}

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoBlobDeathSpot.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoBlobDeathSpot.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.coords.LocalPoint;
 
-class BlobDeathSpot
+class InfernoBlobDeathSpot
 {
 
 	static final int BLOB_DEATH_TICKS = 3;
@@ -22,7 +22,7 @@ class BlobDeathSpot
 	@Getter(AccessLevel.PACKAGE)
 	private final long deathTime;
 
-	public BlobDeathSpot(LocalPoint location)
+	public InfernoBlobDeathSpot(LocalPoint location)
 	{
 		this.location = location;
 		this.ticksUntilDone = BLOB_DEATH_TICKS;

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
@@ -562,7 +562,10 @@ public interface InfernoConfig extends Config
 		position = 2,
 		keyName = "ticksOnNpcMeleerDig",
 		name = "Dig Timer",
-		description = "Draws the amount of ticks before the melee will begin the dig animation",
+		description = "Draws the amount of ticks before the melee will begin the dig animation.\n" +
+			"The amount of time is currently unknown. Plugin will count up to 50 \n" +
+			"then count up with the danger overlay. This should give a general idea of the time. \n" +
+			"Once more data can be collected this can be improved",
 		section = MeleersSection
 	)
 	default boolean ticksOnNpcMeleerDig()
@@ -577,7 +580,7 @@ public interface InfernoConfig extends Config
 	@ConfigItem(
 		position = 3,
 		keyName = "digTimerThreshold",
-		name = "Tick Threshold",
+		name = "Tick Draw Threshold",
 		description = "Number at which the dig timer should be drawn",
 		section = MeleersSection,
 		hidden = true,
@@ -585,12 +588,74 @@ public interface InfernoConfig extends Config
 	)
 	default int digTimerThreshold()
 	{
+		return 20;
+	}
+
+	@Range(
+		min = 30,
+		max = 70
+	)
+	@ConfigItem(
+		position = 4,
+		keyName = "digTimerDangerThreshold",
+		name = "Tick Danger Threshold",
+		description = "Number at which the dig timer should be dangerous",
+		section = MeleersSection,
+		hidden = true,
+		unhide = "ticksOnNpcMeleerDig"
+	)
+	default int digTimerDangerThreshold()
+	{
 		return 50;
 	}
 
 
 	@ConfigItem(
-		position = 4,
+		position = 5,
+		keyName = "getMeleeDigSafeColor",
+		name = "Dig Safe Color",
+		description = "Color for melee when can not dig",
+		hidden = true,
+		unhide = "ticksOnNpcMeleerDig",
+		section = MeleersSection
+	)
+	default Color getMeleeDigSafeColor()
+	{
+		return Color.LIGHT_GRAY;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "getMeleeDigDangerColor",
+		name = "Dig Danger Color",
+		description = "Color for melee when it can dig",
+		hidden = true,
+		unhide = "ticksOnNpcMeleerDig",
+		section = MeleersSection
+	)
+	default Color getMeleeDigDangerColor()
+	{
+		return Color.ORANGE;
+	}
+
+	@Range(min = 10,
+		max = 48)
+	@ConfigItem(
+		position = 7,
+		keyName = "getMeleeDigFontSize",
+		name = "Font size",
+		description = "Font size to use under the melee",
+		hidden = true,
+		unhide = "ticksOnNpcMeleerDig",
+		section = MeleersSection
+	)
+	default int getMeleeDigFontSize()
+	{
+		return 11;
+	}
+
+	@ConfigItem(
+		position = 8,
 		keyName = "safespotsMeleer",
 		name = "Safespots",
 		description = "Enable or disable safespot calculation for this specific NPC. 'Tile Safespots' in the 'Safespots' category needs to be turned on for this to take effect.",
@@ -602,7 +667,7 @@ public interface InfernoConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 9,
 		keyName = "indicateNpcPositionMeleer",
 		name = "Indicate Main Tile",
 		description = "Indicate the main tile for multi-tile NPC's. This tile is used for pathfinding.",

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
@@ -32,6 +32,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
 import net.runelite.client.plugins.inferno.displaymodes.InfernoNamingDisplayMode;
 import net.runelite.client.plugins.inferno.displaymodes.InfernoPrayerDisplayMode;
 import net.runelite.client.plugins.inferno.displaymodes.InfernoSafespotDisplayMode;
@@ -457,6 +458,47 @@ public interface InfernoConfig extends Config
 
 	@ConfigItem(
 		position = 2,
+		keyName = "indicateBlobDeathLocation",
+		name = "Indicate Blob Death Location",
+		description = "Highlight the death tiles with a tick countdown until mini-blobs spawn",
+		section = BlobsSection
+	)
+	default boolean indicateBlobDeathLocation()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "getBlobDeathLocationColor",
+		name = "Blob Death Color",
+		description = "Color for blob death location outline",
+		hidden = true,
+		unhide = "indicateBlobDeathLocation",
+		section = BlobsSection
+	)
+	default Color getBlobDeathLocationColor()
+	{
+		return Color.ORANGE;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "blobDeathLocationFade",
+		name = "Fade Tile",
+		description = "Fades the death tile for a smoother transition.",
+		hidden = true,
+		unhide = "indicateBlobDeathLocation",
+		section = BlobsSection
+	)
+	default boolean blobDeathLocationFade()
+	{
+		return true;
+	}
+
+
+	@ConfigItem(
+		position = 5,
 		keyName = "ticksOnNpcBlob",
 		name = "Ticks on NPC",
 		description = "Draws the amount of ticks before an NPC is going to attack on the NPC",
@@ -468,7 +510,7 @@ public interface InfernoConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 6,
 		keyName = "safespotsBlob",
 		name = "Safespots",
 		description = "Enable or disable safespot calculation for this specific NPC. 'Tile Safespots' in the 'Safespots' category needs to be turned on for this to take effect.",
@@ -480,7 +522,7 @@ public interface InfernoConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 7,
 		keyName = "indicateNpcPositionBlob",
 		name = "Indicate Main Tile",
 		description = "Indicate the main tile for multi-tile NPC's. This tile is used for pathfinding.",
@@ -490,6 +532,7 @@ public interface InfernoConfig extends Config
 	{
 		return false;
 	}
+
 
 	@ConfigItem(
 		position = 0,
@@ -517,6 +560,37 @@ public interface InfernoConfig extends Config
 
 	@ConfigItem(
 		position = 2,
+		keyName = "ticksOnNpcMeleerDig",
+		name = "Dig Timer",
+		description = "Draws the amount of ticks before the melee will begin the dig animation",
+		section = MeleersSection
+	)
+	default boolean ticksOnNpcMeleerDig()
+	{
+		return false;
+	}
+
+	@Range(
+		min = 1,
+		max = 50
+	)
+	@ConfigItem(
+		position = 3,
+		keyName = "digTimerThreshold",
+		name = "Tick Threshold",
+		description = "Number at which the dig timer should be drawn",
+		section = MeleersSection,
+		hidden = true,
+		unhide = "ticksOnNpcMeleerDig"
+	)
+	default int digTimerThreshold()
+	{
+		return 50;
+	}
+
+
+	@ConfigItem(
+		position = 4,
 		keyName = "safespotsMeleer",
 		name = "Safespots",
 		description = "Enable or disable safespot calculation for this specific NPC. 'Tile Safespots' in the 'Safespots' category needs to be turned on for this to take effect.",
@@ -528,7 +602,7 @@ public interface InfernoConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 5,
 		keyName = "indicateNpcPositionMeleer",
 		name = "Indicate Main Tile",
 		description = "Indicate the main tile for multi-tile NPC's. This tile is used for pathfinding.",

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoConfig.java
@@ -43,7 +43,7 @@ public interface InfernoConfig extends Config
 {
 	@ConfigSection(
 		name = "Prayer",
-		description = "Configuration options forPprayer",
+		description = "Configuration options for prayer",
 		position = 0,
 		keyName = "PrayerSection"
 	)
@@ -139,7 +139,7 @@ public interface InfernoConfig extends Config
 
 	@ConfigSection(
 		name = "Zuk",
-		description = "Configuration options for  Zuk",
+		description = "Configuration options for Zuk",
 		position = 12,
 		keyName = "ZukSection"
 	)
@@ -362,7 +362,7 @@ public interface InfernoConfig extends Config
 		position = 0,
 		keyName = "indicateNibblers",
 		name = "Indicate Nibblers",
-		description = "Indicate's nibblers that are alive",
+		description = "Indicates nibblers that are alive",
 		section = NibblersSection
 	)
 	default boolean indicateNibblers()
@@ -446,7 +446,7 @@ public interface InfernoConfig extends Config
 	@ConfigItem(
 		position = 1,
 		keyName = "indicateBlobDetectionTick",
-		name = "Indicate Blob Dection Tick",
+		name = "Indicate Blob Detection Tick",
 		description = "Show a prayer indicator (default: magic) for the tick on which the blob will detect prayer",
 		section = BlobsSection
 	)

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoNPC.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoNPC.java
@@ -65,6 +65,8 @@ class InfernoNPC
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
 	private int ticksTillNextAttack;
+	@Getter(AccessLevel.PACKAGE)
+	private int idleTicks;
 	private int lastAnimation;
 	private boolean lastCanAttack;
 	//0 = not in LOS, 1 = in LOS after move, 2 = in LOS
@@ -78,11 +80,13 @@ class InfernoNPC
 		this.ticksTillNextAttack = 0;
 		this.lastAnimation = -1;
 		this.lastCanAttack = false;
+		this.idleTicks = 0;
 		this.safeSpotCache = new HashMap<>();
 	}
 
 	void updateNextAttack(Attack nextAttack, int ticksTillNextAttack)
 	{
+		this.idleTicks = 0;
 		this.nextAttack = nextAttack;
 		this.ticksTillNextAttack = ticksTillNextAttack;
 	}
@@ -189,6 +193,7 @@ class InfernoNPC
 	void gameTick(Client client, WorldPoint lastPlayerLocation, boolean finalPhase, int ticksSinceFinalPhase)
 	{
 		safeSpotCache.clear();
+		this.idleTicks += 1;
 
 		if (ticksTillNextAttack > 0)
 		{

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
@@ -641,11 +641,4 @@ public class InfernoOverlay extends Overlay
 			renderTextLocation(graphics, canvasCenterPoint, txtString, fontColor);
 		}
 	}
-
-	private Point centerPoint(Rectangle rect)
-	{
-		int x = (int) (rect.getX() + rect.getWidth() / 2);
-		int y = (int) (rect.getY() + rect.getHeight() / 2);
-		return new Point(x, y);
-	}
 }

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
@@ -403,6 +403,9 @@ public class InfernoOverlay extends Overlay
 		final Color color = (infernoNPC.getTicksTillNextAttack() == 1
 			|| (infernoNPC.getType() == InfernoNPC.Type.BLOB && infernoNPC.getTicksTillNextAttack() == 4))
 			? infernoNPC.getNextAttack().getCriticalColor() : infernoNPC.getNextAttack().getNormalColor();
+
+		graphics.setFont(new Font("Arial",  plugin.getFontStyle().getFont(), plugin.getTextSize()));
+
 		final Point canvasPoint = renderOnNPC.getCanvasTextLocation(
 			graphics, String.valueOf(infernoNPC.getTicksTillNextAttack()), 0);
 		renderTextLocation(graphics, String.valueOf(infernoNPC.getTicksTillNextAttack()),

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
@@ -73,6 +73,11 @@ public class InfernoOverlay extends Overlay
 			renderIndividualTilesSafespots(graphics);
 		}
 
+		if (config.indicateBlobDeathLocation())
+		{
+			renderBlobDeathPoly(graphics);
+		}
+
 		for (InfernoNPC infernoNPC : plugin.getInfernoNpcs())
 		{
 			if (infernoNPC.getNpc().getConvexHull() != null)
@@ -304,6 +309,36 @@ public class InfernoOverlay extends Overlay
 			}
 
 		}
+	}
+
+	private void renderBlobDeathPoly(Graphics2D graphics)
+	{
+		graphics.setColor(config.getBlobDeathLocationColor());
+
+		plugin.getBlobDeathSpots().forEach(blobDeathSpot -> {
+			Polygon area = Perspective.getCanvasTileAreaPoly(client, blobDeathSpot.getLocation(), 3);
+
+
+			Color color = config.getBlobDeathLocationColor();
+			if (config.blobDeathLocationFade())
+			{
+				color = new Color(color.getRed(), color.getGreen(), color.getBlue(), blobDeathSpot.fillAlpha());
+			}
+
+			renderOutlinePolygon(graphics, area, color);
+
+			graphics.setFont(new Font("Arial", Font.BOLD, plugin.getTextSize()));
+			String ticks = String.valueOf(blobDeathSpot.getTicksUntilDone());
+
+			renderTextLocation(graphics,
+				ticks,
+				plugin.getTextSize(),
+				plugin.getFontStyle().getFont(),
+				config.getBlobDeathLocationColor(),
+				Perspective.getCanvasTextLocation(client, graphics, blobDeathSpot.getLocation(), ticks, 0),
+				false,
+				0);
+		});
 	}
 
 	private void renderIndividualTilesSafespots(Graphics2D graphics)
@@ -566,5 +601,12 @@ public class InfernoOverlay extends Overlay
 			}
 			renderTextLocation(graphics, canvasCenterPoint, txtString, fontColor);
 		}
+	}
+
+	private Point centerPoint(Rectangle rect)
+	{
+		int x = (int) (rect.getX() + rect.getWidth() / 2);
+		int y = (int) (rect.getY() + rect.getHeight() / 2);
+		return new Point(x, y);
 	}
 }

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoOverlay.java
@@ -132,6 +132,14 @@ public class InfernoOverlay extends Overlay
 			{
 				renderTicksOnNpc(graphics, infernoNPC, plugin.getZukShield());
 			}
+
+			if (config.ticksOnNpcMeleerDig()
+				&& infernoNPC.getType() == InfernoNPC.Type.MELEE
+				&& infernoNPC.getIdleTicks() >= config.digTimerThreshold()
+				&& infernoNPC.getTicksTillNextAttack() == 0) // don't clobber the attack timer
+			{
+				renderDigTimer(graphics, infernoNPC);
+			}
 		}
 
 		var prayerWidgetHidden =
@@ -311,6 +319,34 @@ public class InfernoOverlay extends Overlay
 		}
 	}
 
+	private void renderDigTimer(Graphics2D g, InfernoNPC npc)
+	{
+		String tickString = Integer.toString(npc.getIdleTicks());
+		g.setFont(new Font("Arial", plugin.getFontStyle().getFont(), config.getMeleeDigFontSize()));
+		Point canvasLocation = npc.getNpc().getCanvasTextLocation(g, tickString, 0);
+
+		if (canvasLocation == null)
+		{
+			return;
+		}
+
+		// NEEDS TO BE WORKED ON WITH SOME STATS
+		// MELEE DIG IS UNKNOWN AT THIS TIME
+		// COLLECTING DATA
+		Color digColor;
+		if (npc.getIdleTicks() < config.digTimerDangerThreshold())
+		{
+			digColor = config.getMeleeDigSafeColor();
+		}
+		else
+		{
+			digColor = config.getMeleeDigDangerColor();
+		}
+
+		renderTextLocation(g, tickString, config.getMeleeDigFontSize(), plugin.getFontStyle().getFont(), digColor, canvasLocation, false, 0);
+	}
+
+
 	private void renderBlobDeathPoly(Graphics2D graphics)
 	{
 		graphics.setColor(config.getBlobDeathLocationColor());
@@ -404,7 +440,7 @@ public class InfernoOverlay extends Overlay
 			|| (infernoNPC.getType() == InfernoNPC.Type.BLOB && infernoNPC.getTicksTillNextAttack() == 4))
 			? infernoNPC.getNextAttack().getCriticalColor() : infernoNPC.getNextAttack().getNormalColor();
 
-		graphics.setFont(new Font("Arial",  plugin.getFontStyle().getFont(), plugin.getTextSize()));
+		graphics.setFont(new Font("Arial", plugin.getFontStyle().getFont(), plugin.getTextSize()));
 
 		final Point canvasPoint = renderOnNPC.getCanvasTextLocation(
 			graphics, String.valueOf(infernoNPC.getTicksTillNextAttack()), 0);

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -159,7 +159,7 @@ public class InfernoPlugin extends Plugin
 	private final Map<Integer, List<WorldPoint>> safeSpotAreas = new HashMap<>();
 
 	@Getter(AccessLevel.PACKAGE)
-	List<BlobDeathSpot> blobDeathSpots = new ArrayList<>();
+	List<InfernoBlobDeathSpot> blobDeathSpots = new ArrayList<>();
 
 	@Getter(AccessLevel.PACKAGE)
 	private long lastTick;
@@ -416,12 +416,12 @@ public class InfernoPlugin extends Plugin
 			}
 
 
-			if (config.indicateBlobDeathLocation() && InfernoNPC.Type.typeFromId(npc.getId()) == InfernoNPC.Type.BLOB && npc.getAnimation() == BlobDeathSpot.BLOB_DEATH_ANIMATION)
+			if (config.indicateBlobDeathLocation() && InfernoNPC.Type.typeFromId(npc.getId()) == InfernoNPC.Type.BLOB && npc.getAnimation() == InfernoBlobDeathSpot.BLOB_DEATH_ANIMATION)
 			{
 				// Remove from list so the ticks overlay doesn't compete
 				// with the tile overlay.
 				infernoNpcs.removeIf(infernoNPC -> infernoNPC.getNpc() == npc);
-				blobDeathSpots.add(new BlobDeathSpot(npc.getLocalLocation()));
+				blobDeathSpots.add(new InfernoBlobDeathSpot(npc.getLocalLocation()));
 			}
 
 		}
@@ -932,8 +932,8 @@ public class InfernoPlugin extends Plugin
 
 	private void manageBlobDeathLocations()
 	{
-		blobDeathSpots.forEach(BlobDeathSpot::decrementTick);
-		blobDeathSpots.removeIf(BlobDeathSpot::isDone);
+		blobDeathSpots.forEach(InfernoBlobDeathSpot::decrementTick);
+		blobDeathSpots.removeIf(InfernoBlobDeathSpot::isDone);
 	}
 
 	private void calculateCentralNibbler()

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -932,8 +932,11 @@ public class InfernoPlugin extends Plugin
 
 	private void manageBlobDeathLocations()
 	{
-		blobDeathSpots.forEach(InfernoBlobDeathSpot::decrementTick);
-		blobDeathSpots.removeIf(InfernoBlobDeathSpot::isDone);
+		if (config.indicateBlobDeathLocation())
+		{
+			blobDeathSpots.forEach(InfernoBlobDeathSpot::decrementTick);
+			blobDeathSpots.removeIf(InfernoBlobDeathSpot::isDone);
+		}
 	}
 
 	private void calculateCentralNibbler()

--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -159,6 +159,9 @@ public class InfernoPlugin extends Plugin
 	private final Map<Integer, List<WorldPoint>> safeSpotAreas = new HashMap<>();
 
 	@Getter(AccessLevel.PACKAGE)
+	List<BlobDeathSpot> blobDeathSpots = new ArrayList<>();
+
+	@Getter(AccessLevel.PACKAGE)
 	private long lastTick;
 
 	private InfernoSpawnTimerInfobox spawnTimerInfoBox;
@@ -273,6 +276,8 @@ public class InfernoPlugin extends Plugin
 		calculateCentralNibbler();
 
 		calculateSpawnTimerInfobox();
+
+		manageBlobDeathLocations();
 
 		//if finalPhaseTick, we will skip incrementing because we already did it in onNpcSpawned
 		if (finalPhaseTick)
@@ -409,6 +414,16 @@ public class InfernoPlugin extends Plugin
 			{
 				infernoNpcs.removeIf(infernoNPC -> infernoNPC.getNpc() == npc);
 			}
+
+
+			if (config.indicateBlobDeathLocation() && InfernoNPC.Type.typeFromId(npc.getId()) == InfernoNPC.Type.BLOB && npc.getAnimation() == BlobDeathSpot.BLOB_DEATH_ANIMATION)
+			{
+				// Remove from list so the ticks overlay doesn't compete
+				// with the tile overlay.
+				infernoNpcs.removeIf(infernoNPC -> infernoNPC.getNpc() == npc);
+				blobDeathSpots.add(new BlobDeathSpot(npc.getLocalLocation()));
+			}
+
 		}
 	}
 
@@ -913,6 +928,12 @@ public class InfernoPlugin extends Plugin
 		{
 			obstacles.addAll(npc.getWorldArea().toWorldPointList());
 		}
+	}
+
+	private void manageBlobDeathLocations()
+	{
+		blobDeathSpots.forEach(BlobDeathSpot::decrementTick);
+		blobDeathSpots.removeIf(BlobDeathSpot::isDone);
 	}
 
 	private void calculateCentralNibbler()


### PR DESCRIPTION
- Adds an idle tick timer to InfernoNPC to track melees and give hints on their digging. Data collection tool being worked on to try and work out how their dig rng works.

- Adds a blob death location indicator to help with speeding when using entity hider extended

- Fix text rendering not setting font size before calculating canvas location. 

- typos
