### PR TITLE
zulrah: Fix jad phase prayers

### DIFF
--- a/zulrah/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.java
+++ b/zulrah/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.java
@@ -316,7 +316,7 @@ public class ZulrahPlugin extends Plugin implements KeyListener
 			case 5069:
 			{
 				attackTicks = 4;
-				if (currentRotation == null || !getCurrentPhase(currentRotation).getZulrahNpc().isJad() || zulrahNpc.getInteracting() != client.getLocalPlayer()) break;
+				if (currentRotation == null || !getCurrentPhase(currentRotation).getZulrahNpc().isJad()) break;
 				flipPhasePrayer = !flipPhasePrayer;
 				break;
 			}

--- a/zulrah/src/main/java/net/runelite/client/plugins/zulrah/rotationutils/ZulrahData.java
+++ b/zulrah/src/main/java/net/runelite/client/plugins/zulrah/rotationutils/ZulrahData.java
@@ -89,7 +89,7 @@ public class ZulrahData
 		{
 			Prayer phasePrayer = current.getAttributes().getPrayer();
 			Prayer invertedPhasePrayer = phasePrayer == Prayer.PROTECT_FROM_MAGIC ? Prayer.PROTECT_FROM_MISSILES : Prayer.PROTECT_FROM_MAGIC;
-			return isJad() ? (ZulrahPlugin.isFlipPhasePrayer() ? Optional.of(phasePrayer) : Optional.of(invertedPhasePrayer)) : Optional.of(phasePrayer);
+			return isJad() ? (ZulrahPlugin.isFlipPhasePrayer() ? Optional.of(invertedPhasePrayer) : Optional.of(phasePrayer)) : Optional.of(phasePrayer);
 		}
 		else
 		{

--- a/zulrah/zulrah.gradle.kts
+++ b/zulrah/zulrah.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.4"
+version = "5.0.5"
 
 project.extra["PluginName"] = "Zulrah"
 project.extra["PluginDescription"] = "Shows tiles on where to stand during the phases and what prayer to use"


### PR DESCRIPTION
Fix: was showing wront prayer for the first jad attack.

My last zulrah fix inverted the prayers for the jad phase because the plugin was always incorrect in which to pray. Turns out the real core of the issue was that the flipped indicator was not properly updated at the start of jad phase. This means that the plugin was correct for all but the first attack. The plugin now shows proper prayers for the whole jad phase. 

-revert invert of prayers
-fix flipped bool