### PR TITLE
AlchemicalHydra: Delay setImmunity

### DIFF
--- a/alchemicalhydra/alchemicalhydra.gradle.kts
+++ b/alchemicalhydra/alchemicalhydra.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.6"
+version = "5.0.7"
 
 project.extra["PluginName"] = "Alchemical Hydra"
 project.extra["PluginDescription"] = "A plugin for the Alchemical Hydra boss."

--- a/alchemicalhydra/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraPlugin.java
+++ b/alchemicalhydra/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraPlugin.java
@@ -52,6 +52,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.ProjectileMoved;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
@@ -82,6 +83,10 @@ public class AlchemicalHydraPlugin extends Plugin
 
 	@Inject
 	private Client client;
+	
+	@Getter
+	@Inject
+	private ClientThread clientThread;
 
 	@Inject
 	private OverlayManager overlayManager;
@@ -374,7 +379,10 @@ public class AlchemicalHydraPlugin extends Plugin
 
 		if (message.equals(MESSAGE_NEUTRALIZE))
 		{
-			hydra.setImmunity(false);
+			clientThread.invokeLater(() ->
+			{
+				hydra.setImmunity(false);
+			});
 		}
 		else if (message.equals(MESSAGE_STUN))
 		{


### PR DESCRIPTION
This delays setting immunity to later in the tick since onChatMessage events are sent before onAnimationChanged causing the plugin to show hydra as immune if the phase change finished as the vent triggered immunity for next phase.