### PR TITLE
nex: 5.0.6

### DIFF
--- a/nex/nex.gradle.kts
+++ b/nex/nex.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "5.0.5"
+version = "5.0.6"
 
 project.extra["PluginName"] = "Nex Extended"
 project.extra["PluginDescription"] = "Helper for fighting Nex"

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
@@ -502,7 +502,7 @@ public interface NexConfig extends Config
 	@ConfigItem(
 		position = 401,
 		keyName = "indicateSacrificeAOE",
-		name = "BETA: Sacrifice Safe Line",
+		name = "Sacrifice Safe Line",
 		description = "Highlight the tiles where you wont heal nex. please report back any bugs",
 		section = bloodSection
 	)

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
@@ -737,7 +737,7 @@ public interface NexConfig extends Config
 	}
 
 	@Range(
-		min = 0,
+		min = 4,
 		max = 100
 	)
 	@ConfigItem(

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
@@ -293,6 +293,33 @@ public interface NexConfig extends Config
 		return new Color(48, 164, 255, 200);
 	}
 
+	@ConfigItem(
+		position = 119,
+		keyName = "indicateNexRange",
+		name = "Indicate Nex Range",
+		description = "Highlight the tiles where standing on or inside will allow next to deal damage to you.",
+		section = generalSection
+	)
+	default boolean indicateNexRange()
+	{
+		return false;
+	}
+
+	@Alpha
+	@ConfigItem(
+		position = 120,
+		keyName = "indicateNexRangeColor",
+		name = "Range Color",
+		description = "Color for the tiles",
+		hidden = true,
+		unhide = "indicateNexRange",
+		section = generalSection
+	)
+	default Color indicateNexRangeColor()
+	{
+		return new Color(28, 0, 0, 50);
+	}
+
 	@ConfigSection(
 		name = "Smoke Settings",
 		description = "Configure settings for the virus",

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
@@ -297,7 +297,7 @@ public interface NexConfig extends Config
 		position = 119,
 		keyName = "indicateNexRange",
 		name = "Indicate Nex Range",
-		description = "Highlight the tiles where standing on or inside will allow next to deal damage to you.",
+		description = "Highlight the tiles where standing on or inside will allow nex to deal damage to you.",
 		section = generalSection
 	)
 	default boolean indicateNexRange()
@@ -317,7 +317,48 @@ public interface NexConfig extends Config
 	)
 	default Color indicateNexRangeColor()
 	{
-		return new Color(28, 0, 0, 50);
+		return new Color(0, 0, 0, 50);
+	}
+
+	@ConfigItem(
+		keyName = "drawDashLane",
+		name = "Dash Lane Highlight",
+		description = "Draw dash lane aoe",
+		position = 121,
+		section = generalSection
+	)
+	default boolean drawDashLane()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "drawTicksOnDash",
+		name = "Dash Ticks",
+		description = "Draw ticks on ice trap",
+		position = 122,
+		hidden = true,
+		unhide = "drawDashLane",
+		section = generalSection
+	)
+	default boolean drawTicksOnDash()
+	{
+		return true;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "drawDashLaneColor",
+		name = "Dash Color",
+		description = "Color ya idiot",
+		position = 123,
+		hidden = true,
+		unhide = "drawDashLane",
+		section = generalSection
+	)
+	default Color drawDashLaneColor()
+	{
+		return new Color(255, 0, 98, 100);
 	}
 
 	@ConfigSection(
@@ -595,7 +636,6 @@ public interface NexConfig extends Config
 	{
 		return new Color(255, 0, 98, 100);
 	}
-
 
 	@ConfigItem(
 		position = 504,

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
@@ -452,7 +452,6 @@ public interface NexConfig extends Config
 		return 6;
 	}
 
-
 	@ConfigItem(
 		keyName = "shadowsTickCounter",
 		name = "Shadows Tick Counter",
@@ -477,7 +476,6 @@ public interface NexConfig extends Config
 	{
 		return new Color(0, 255, 255, 100);
 	}
-
 
 	@ConfigItem(
 		keyName = "shadowStandingFlash",

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexConfig.java
@@ -712,6 +712,46 @@ public interface NexConfig extends Config
 		return new Color(255, 0, 98, 100);
 	}
 
+	@ConfigItem(
+		position = 603,
+		keyName = "indicateTankSwitchTicks",
+		name = "Ticks: Tank Switch",
+		description = "countdown until tank switches",
+		section = zarosSection
+	)
+	default boolean indicateTankSwitchTicks()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 604,
+		keyName = "indicatePraySwitchTicks",
+		name = "Ticks: Prayer Switch",
+		description = "countdown until nex's prayer switches",
+		section = zarosSection
+	)
+	default boolean indicatePraySwitchTicks()
+	{
+		return true;
+	}
+
+	@Range(
+		min = 0,
+		max = 100
+	)
+	@ConfigItem(
+		position = 605,
+		keyName = "counterZOffset",
+		name = "Z offset",
+		description = "how far down to render below hp (if hp is present)",
+		section = zarosSection
+	)
+	default int counterZOffset()
+	{
+		return 16;
+	}
+
 	enum PrayerDisplay
 	{
 		PRAYER_TAB,

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexOverlay.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexOverlay.java
@@ -84,6 +84,11 @@ class NexOverlay extends Overlay
 			return null;
 		}
 
+		if (config.indicateTank())
+		{
+			drawTank(graphics);
+		}
+
 		if (config.indicateContainAOE() && plugin.getContainTrapTicks().isActive())
 		{
 			drawObjectTickable(
@@ -177,11 +182,6 @@ class NexOverlay extends Overlay
 		if (config.drawMinionHP() && plugin.isMinionActive())
 		{
 			drawMinionHP(graphics);
-		}
-
-		if (config.indicateTank())
-		{
-			drawTank(graphics);
 		}
 
 		if (config.flash() && plugin.isFlash())

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexOverlay.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexOverlay.java
@@ -137,7 +137,12 @@ class NexOverlay extends Overlay
 
 		if (config.indicateSacrificeAOE() && plugin.getBloodSacrificeTicks().isActive())
 		{
-			drawBloodSacrificeSafeZone(graphics);
+			drawAreaTiles(graphics, plugin.getBloodSacrificeSafeTiles(), config.indicateSacrificeAOEColor(), 1);
+		}
+
+		if (config.indicateNexRange())
+		{
+			drawAreaTiles(graphics, plugin.getNexRangeTiles(), config.indicateNexRangeColor(), 1);
 		}
 
 		if (plugin.nexDisable())
@@ -368,30 +373,29 @@ class NexOverlay extends Overlay
 		graphics.fill(infecetedTiles);
 	}
 
-	private void drawBloodSacrificeSafeZone(Graphics2D graphics)
+	private void drawAreaTiles(Graphics2D graphics, List<LocalPoint> tiles, Color color, int size)
 	{
-		if (plugin.getBloodSacrificeSafeTiles().isEmpty())
+		if (tiles.isEmpty())
 		{
 			return;
 		}
 
-		Area safeTiles = new Area();
+		Area area = new Area();
 
-		plugin
-			.getBloodSacrificeSafeTiles()
-			.forEach(p -> {
-				Polygon poly = getCanvasTileAreaPoly(client, p, 1);
-				if (poly != null)
-				{
-					safeTiles.add(new Area(poly));
-				}
-			});
+		tiles.forEach(p -> {
+			Polygon poly = getCanvasTileAreaPoly(client, p, size);
+
+			if (poly != null)
+			{
+				area.add(new Area(poly));
+			}
+		});
 
 		graphics.setPaintMode();
-		graphics.setColor(config.indicateSacrificeAOEColor());
-		graphics.draw(safeTiles);
-		graphics.setColor(getFillColor(config.indicateSacrificeAOEColor()));
-		graphics.fill(safeTiles);
+		graphics.setColor(color);
+		graphics.draw(area);
+		graphics.setColor(getFillColor(color));
+		graphics.fill(area);
 	}
 
 

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexOverlay.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexOverlay.java
@@ -137,12 +137,17 @@ class NexOverlay extends Overlay
 
 		if (config.indicateSacrificeAOE() && plugin.getBloodSacrificeTicks().isActive())
 		{
-			drawAreaTiles(graphics, plugin.getBloodSacrificeSafeTiles(), config.indicateSacrificeAOEColor(), 1);
+			drawAreaTiles(graphics, plugin.getBloodSacrificeSafeTiles(), config.indicateSacrificeAOEColor(), 1, false, 0);
 		}
 
 		if (config.indicateNexRange())
 		{
-			drawAreaTiles(graphics, plugin.getNexRangeTiles(), config.indicateNexRangeColor(), 1);
+			drawAreaTiles(graphics, plugin.getNexRangeTiles(), config.indicateNexRangeColor(), 1, false, 0);
+		}
+
+		if (config.drawDashLane() && plugin.getAirplaneCoolDown().isActive())
+		{
+			drawAreaTiles(graphics, plugin.getDashLaneTiles(), config.drawDashLaneColor(), 3, true, plugin.getAirplaneCoolDown().getTicks());
 		}
 
 		if (plugin.nexDisable())
@@ -373,7 +378,7 @@ class NexOverlay extends Overlay
 		graphics.fill(infecetedTiles);
 	}
 
-	private void drawAreaTiles(Graphics2D graphics, List<LocalPoint> tiles, Color color, int size)
+	private void drawAreaTiles(Graphics2D graphics, List<LocalPoint> tiles, Color color, int size, boolean drawTicks, int ticksRemaining)
 	{
 		if (tiles.isEmpty())
 		{
@@ -396,6 +401,19 @@ class NexOverlay extends Overlay
 		graphics.draw(area);
 		graphics.setColor(getFillColor(color));
 		graphics.fill(area);
+
+		if (drawTicks)
+		{
+			graphics.setFont(new Font("Arial", Font.BOLD, 16));
+			String ticks = String.valueOf(ticksRemaining);
+
+			OverlayUtil.renderTextLocation(
+				graphics,
+				Perspective.getCanvasTextLocation(client, graphics, tiles.get(tiles.size() / 2), ticks, 0),
+				ticks,
+				Color.WHITE
+			);
+		}
 	}
 
 

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexOverlay.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexOverlay.java
@@ -189,6 +189,11 @@ class NexOverlay extends Overlay
 			drawNexHpOverlay(graphics);
 		}
 
+		if (plugin.getCurrentPhase() == NexPhase.ZAROS && (config.indicateTankSwitchTicks() || config.indicatePraySwitchTicks()))
+		{
+			drawTankAndPrayTicks(graphics);
+		}
+
 		if (config.drawMinionHP() && plugin.isMinionActive())
 		{
 			drawMinionHP(graphics);
@@ -471,6 +476,47 @@ class NexOverlay extends Overlay
 		{
 			Color color = percentageToColor(relativeHP);
 			OverlayUtil.renderTextLocation(graphics, textLocation, text, color);
+		}
+	}
+
+	private void drawTankAndPrayTicks(Graphics2D graphics)
+	{
+		if (config.indicateInvulnerableNexTicks() && plugin.getNexTicksUntilClick().isActive())
+		{
+			return;
+		}
+
+		var zOffset = 0;
+		if (config.drawNexHp())
+		{
+			zOffset = config.counterZOffset();
+		}
+		// SAFETY: not null checked before call
+		var nex = plugin.getNex();
+
+		StringBuilder text = new StringBuilder();
+
+		if (config.indicateTankSwitchTicks())
+		{
+			text.append(4 - (plugin.getNexAttacks() % 4));
+		}
+
+		if (config.indicatePraySwitchTicks())
+		{
+			if (text.length() != 0)
+			{
+				text.append(" | ");
+			}
+			text.append(5 - (plugin.getNexAttacks() % 5));
+		}
+
+		var finalText = text.toString();
+		graphics.setFont(new Font("Arial", Font.BOLD, 12));
+		Point textLocation = nex.getCanvasTextLocation(graphics, finalText, 0);
+
+		if (!nex.isDead() && textLocation != null)
+		{
+			OverlayUtil.renderTextLocation(graphics, new Point(textLocation.getX(), textLocation.getY() + zOffset), finalText, Color.WHITE);
 		}
 	}
 

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexPlugin.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexPlugin.java
@@ -201,6 +201,10 @@ public class NexPlugin extends Plugin
 	@Getter
 	private final TickTimer nexDeathTileTicks = new TickTimer(() -> nexDeathTile = null);
 
+	@Getter
+	private int nexAttacks = 0;
+	private int nexPreviousAnimation = -1;
+
 	@Provides
 	NexConfig provideConfig(ConfigManager configManager)
 	{
@@ -254,6 +258,8 @@ public class NexPlugin extends Plugin
 		containThisSpawns.clear();
 		nexTicksUntilClick.reset();
 		iceTraps.clear();
+		nexAttacks = 0;
+		nexPreviousAnimation = -1;
 		iceTrapTicks.reset();
 		teamSize = 0;
 		coughingPlayersChanged = false;
@@ -285,6 +291,19 @@ public class NexPlugin extends Plugin
 			// Handle edge case where because we arent in fight yet
 			// we wont see her spawning text
 			nexTicksUntilClick.setTicks(NEX_STARTUP_DELAY);
+		}
+
+		if (nex != null && currentPhase == NexPhase.ZAROS)
+		{
+			if (nex.getAnimation() != nexPreviousAnimation)
+			{
+				if (nex.getAnimation() != -1)
+				{
+					nexAttacks += 1;
+				}
+
+				nexPreviousAnimation = nex.getAnimation();
+			}
 		}
 	}
 
@@ -519,6 +538,12 @@ public class NexPlugin extends Plugin
 
 		if (setPhase(message))
 		{
+			if (currentPhase == NexPhase.ZAROS)
+			{
+				nexAttacks = 0;
+				nexPreviousAnimation = -1;
+			}
+
 			if (currentPhase == NexPhase.NONE)
 			{
 				// TASTE MY WRATH!

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexPlugin.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexPlugin.java
@@ -81,7 +81,7 @@ public class NexPlugin extends Plugin
 
 	private static final int SHADOW_TICK_LEN = 5;
 	private static final int BLOOD_SACRIFICE_LEN = 7;
-	private static final int BLOOD_SACRIFICE_DISTANCE = 8;
+	private static final int BLOOD_SACRIFICE_DISTANCE = 9;
 	private static final int ICE_TRAP_TICK_LEN = 9;
 	private static final int CONTAIN_THIS_TICK_LEN = 6;
 	private static final int CONTAIN_THIS_DISTANCE = 2;

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexPlugin.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexPlugin.java
@@ -204,6 +204,7 @@ public class NexPlugin extends Plugin
 	@Getter
 	private int nexAttacks = 0;
 	private int nexPreviousAnimation = -1;
+	Set<Integer> nexAttackAnimations = Set.of(9189, 9180);
 
 	@Provides
 	NexConfig provideConfig(ConfigManager configManager)
@@ -285,6 +286,7 @@ public class NexPlugin extends Plugin
 			centerTile = getNexCenterTile(nex);
 			updateWingTiles(centerTile);
 
+			//9180
 			inFight = true;
 
 			// first discover nex, oh wow, fun boss.
@@ -297,7 +299,7 @@ public class NexPlugin extends Plugin
 		{
 			if (nex.getAnimation() != nexPreviousAnimation)
 			{
-				if (nex.getAnimation() != -1)
+				if (nexAttackAnimations.contains(nex.getAnimation()))
 				{
 					nexAttacks += 1;
 				}

--- a/nex/src/main/java/net/runelite/client/plugins/nex/NexPlugin.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/NexPlugin.java
@@ -81,7 +81,7 @@ public class NexPlugin extends Plugin
 
 	private static final int SHADOW_TICK_LEN = 5;
 	private static final int BLOOD_SACRIFICE_LEN = 7;
-	private static final int BLOOD_SACRIFICE_DISTANCE = 9;
+	private static final int BLOOD_SACRIFICE_DISTANCE = 8;
 	private static final int ICE_TRAP_TICK_LEN = 9;
 	private static final int CONTAIN_THIS_TICK_LEN = 6;
 	private static final int CONTAIN_THIS_DISTANCE = 2;

--- a/nex/src/main/java/net/runelite/client/plugins/nex/maths/MathUtil.java
+++ b/nex/src/main/java/net/runelite/client/plugins/nex/maths/MathUtil.java
@@ -1,0 +1,31 @@
+package net.runelite.client.plugins.nex.maths;
+
+import net.runelite.api.coords.WorldPoint;
+
+public class MathUtil
+{
+	public static double[] unitVec(WorldPoint a, WorldPoint b)
+	{
+		var x = b.getX() - a.getX();
+		var y = b.getY() - a.getY();
+		var m = Math.hypot(x, y);
+
+		return new double[]{x / m, y / m};
+	}
+
+	public static double cosineSimilarity(double[] vectorA, double[] vectorB)
+	{
+		double dotProduct = 0.0;
+		double normA = 0.0;
+		double normB = 0.0;
+
+		for (int i = 0; i < vectorA.length; i++)
+		{
+			dotProduct += vectorA[i] * vectorB[i];
+			normA += Math.pow(vectorA[i], 2);
+			normB += Math.pow(vectorB[i], 2);
+		}
+
+		return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+	}
+}


### PR DESCRIPTION
**changelog 5.0.6**
- add p1 dash lane detection (showing all you kids who don't like math and trig that it can be useful)
- dash support again because its big
- add nex range indicator for safespotting
- move tank earlier in drawing to not hide shadow spawns
- add zaros phase tank and prayer switch indicators

**Testing needed**
- is the tick counter on dash lane correct?
- is the immunity after dash correct?
- do the tank and pray indicators work as expected?