### PR TITLE
Fix gorilla attack styles resetting while attacking with melee

### DIFF
--- a/demonicgorilla/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaPlugin.java
+++ b/demonicgorilla/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaPlugin.java
@@ -350,7 +350,8 @@ public class DemonicGorillaPlugin extends Plugin
 				{
 					onGorillaAttack(gorilla, DemonicGorilla.AttackStyle.RANGED);
 				}
-				else if (animationId == AnimationID.DEMONIC_GORILLA_AOE_ATTACK && interacting != null)
+				else if (animationId == AnimationID.DEMONIC_GORILLA_AOE_ATTACK && interacting != null &&
+					gorilla.getNextPosibleAttackStyles().stream().anyMatch(x -> x == DemonicGorilla.AttackStyle.MAGIC || x == DemonicGorilla.AttackStyle.RANGED))
 				{
 					// Note that AoE animation is the same as prayer switch animation
 					// so we need to check if the prayer was switched or not.


### PR DESCRIPTION
This double checks that the gorilla is using magic or ranged when the animation for the boulder fires.

I think when they changed demonic gorillas in may, they also made them randomly use the AOE_ATTACK animation, even while attacking with melee. They also added a overhead text to them, which triggers occasionally, but doesn't have anything to do with the attack styles as far as I can tell.